### PR TITLE
Allow the document exporter to set a limit on file name length

### DIFF
--- a/docs/administration.md
+++ b/docs/administration.md
@@ -322,11 +322,14 @@ exporter with `crontab`.
 If `--passphrase` is provided, it will be used to encrypt certain fields in the export. This value
 must be provided to import. If this value is lost, the export cannot be imported.
 
-!!! warning
+If `--max-filename-length` is provided, the document exporter will crop the file names
+that exceed the given limit. In this case, the file format may not be respected.
 
-    If exporting with the file name format, there may be errors due to
-    your operating system's maximum path lengths.  Try adjusting the export
-    target or consider not using the filename format.
+!!! warning
+If exporting with the file name format, there may be errors due to
+your operating system's maximum path lengths. Try adjusting the export
+target, or consider not using the filename format.
+In such cases, you should also set a limit with `--max-filename-length`.
 
 ### Document importer {#importer}
 

--- a/src/documents/file_handling.py
+++ b/src/documents/file_handling.py
@@ -96,7 +96,13 @@ def generate_filename(
     counter=0,
     append_gpg=True,
     archive_filename=False,
+    basename_max_length=None,
 ):
+    if basename_max_length and basename_max_length < 15:
+        raise ValueError(
+            f"The base name length limit ({basename_max_length}) should be at least 15 characters",
+        )
+
     path = ""
 
     def format_filename(document: Document, template_str: str) -> str | None:
@@ -135,6 +141,8 @@ def generate_filename(
     # If we have one, render it
     if filename_format is not None:
         path = format_filename(doc, filename_format)
+        if basename_max_length:
+            path = path[:basename_max_length]
 
     counter_str = f"_{counter:02}" if counter else ""
     filetype_str = ".pdf" if archive_filename else doc.file_type

--- a/src/documents/management/commands/document_exporter.py
+++ b/src/documents/management/commands/document_exporter.py
@@ -1,6 +1,7 @@
 import hashlib
 import json
 import os
+import platform
 import shutil
 import tempfile
 import time
@@ -61,6 +62,32 @@ from paperless.models import ApplicationConfiguration
 from paperless_mail.models import MailAccount
 from paperless_mail.models import MailRule
 
+# If the users set a limit on export filename length,
+# we don't have exact controlon how many characters can be added
+# by counters, file extension etc. So we take a security margin.
+# Example of the biggest suffix: "_123456.pdf-thumbnail.webp" (26 chars).
+# Also, make sure that the minimum allowed value minus the suffix margin
+# is long enough to be thread by the filename generators (15 chars min).
+FILENAME_MAX_LENGTH_MIN_VALUE = 45
+FILENAME_MAX_LENGTH_SUFFIX_MARGIN = 26
+
+
+def _check_filesystem_max_filename_length(target) -> int | None:
+    """
+    Return the max allowed filename length by filesystem for a given path.
+
+    Returns None if no limit has been found.
+    """
+    result = None
+    try:
+        system = platform.system()
+        if system in ["Linux", "Darwin"]:
+            result = os.pathconf(target, "PC_NAME_MAX")
+    except Exception:
+        # Could not determine the allowed filesystem
+        pass
+    return result
+
 
 class Command(CryptMixin, BaseCommand):
     help = (
@@ -117,6 +144,13 @@ class Command(CryptMixin, BaseCommand):
                 "Use PAPERLESS_FILENAME_FORMAT for storing files in the "
                 "export directory, if configured."
             ),
+        )
+
+        parser.add_argument(
+            "--max-filename-length",
+            default=0,
+            help="Set an upper limit for file name length, including the extension. If not specified or set to 0, no limit is applied.",
+            type=int,
         )
 
         parser.add_argument(
@@ -194,6 +228,7 @@ class Command(CryptMixin, BaseCommand):
         self.compare_checksums: bool = options["compare_checksums"]
         self.compare_json: bool = options["compare_json"]
         self.use_filename_format: bool = options["use_filename_format"]
+        self.max_filename_length: int = options["max_filename_length"]
         self.use_folder_prefix: bool = options["use_folder_prefix"]
         self.delete: bool = options["delete"]
         self.no_archive: bool = options["no_archive"]
@@ -206,6 +241,27 @@ class Command(CryptMixin, BaseCommand):
         self.files_in_export_dir: set[Path] = set()
         self.exported_files: set[str] = set()
 
+        if self.max_filename_length < 0 or (
+            self.max_filename_length > 0
+            and self.max_filename_length < FILENAME_MAX_LENGTH_MIN_VALUE
+        ):
+            raise CommandError(
+                f"The filename length limit should be set to at least {FILENAME_MAX_LENGTH_MIN_VALUE} characters, or 0 to disable this limit",
+            )
+
+        filesystem_filename_limit = _check_filesystem_max_filename_length(self.target)
+        filesystem_filename_limit = 30
+        if (
+            filesystem_filename_limit
+            and filesystem_filename_limit < 255
+            and (
+                not self.max_filename_length
+                or self.max_filename_length > filesystem_filename_limit
+            )
+        ):
+            print(  # noqa: T201
+                f"WARNING: Your target directory reports a file name limit of {filesystem_filename_limit} character. Make sure to define an appropriate limit with --max-filename-length, otherwise the export might fail.",
+            )
         # If zipping, save the original target for later and
         # get a temporary directory for the target instead
         temp_dir = None
@@ -427,9 +483,15 @@ class Command(CryptMixin, BaseCommand):
                     document,
                     counter=filename_counter,
                     append_gpg=False,
+                    basename_max_length=self.max_filename_length
+                    - FILENAME_MAX_LENGTH_SUFFIX_MARGIN,
                 )
             else:
-                base_name = document.get_public_filename(counter=filename_counter)
+                base_name = document.get_public_filename(
+                    counter=filename_counter,
+                    basename_max_length=self.max_filename_length
+                    - FILENAME_MAX_LENGTH_SUFFIX_MARGIN,
+                )
 
             if base_name not in self.exported_files:
                 self.exported_files.add(base_name)

--- a/src/documents/models.py
+++ b/src/documents/models.py
@@ -332,11 +332,26 @@ class Document(SoftDeleteModel, ModelWithOwner):
     def archive_file(self):
         return Path(self.archive_path).open("rb")
 
-    def get_public_filename(self, *, archive=False, counter=0, suffix=None) -> str:
+    def get_public_filename(
+        self,
+        *,
+        archive=False,
+        counter=0,
+        suffix=None,
+        basename_max_length=None,
+    ) -> str:
         """
         Returns a sanitized filename for the document, not including any paths.
         """
+        if basename_max_length and basename_max_length < 15:
+            raise ValueError(
+                f"The base name length limit ({basename_max_length}) should be at least 15 characters",
+            )
+
         result = str(self)
+
+        if basename_max_length:
+            result = result[:basename_max_length]
 
         if counter:
             result += f"_{counter:02}"

--- a/src/documents/tests/test_document_model.py
+++ b/src/documents/tests/test_document_model.py
@@ -4,6 +4,7 @@ import zoneinfo
 from pathlib import Path
 from unittest import mock
 
+import pytest
 from django.test import TestCase
 from django.test import override_settings
 from django.utils import timezone
@@ -84,6 +85,18 @@ class TestDocument(TestCase):
             created=timezone.datetime(2020, 12, 25, tzinfo=zoneinfo.ZoneInfo("UTC")),
         )
         self.assertEqual(doc.get_public_filename(), "2020-12-25 test.pdf")
+
+    def test_shorter_file_name_for_archive(self):
+        doc = Document(
+            mime_type="application/pdf",
+            title="This file has a very long filename that will exceed filename limits on some obscure filesystems, such as eCryptfs which accepts up to 143 characters",
+            created=timezone.datetime(2025, 3, 7, tzinfo=zoneinfo.ZoneInfo("UTC")),
+        )
+        self.assertEqual(len(doc.get_public_filename()), 163)
+        self.assertLessEqual(len(doc.get_public_filename(basename_max_length=120)), 143)
+        self.assertLessEqual(len(doc.get_public_filename(basename_max_length=15)), 143)
+        with pytest.raises(ValueError):
+            doc.get_public_filename(basename_max_length=14)
 
     @override_settings(
         TIME_ZONE="Europe/Berlin",

--- a/src/documents/tests/test_file_handling.py
+++ b/src/documents/tests/test_file_handling.py
@@ -5,6 +5,7 @@ import tempfile
 from pathlib import Path
 from unittest import mock
 
+import pytest
 from auditlog.context import disable_auditlog
 from django.conf import settings
 from django.contrib.auth.models import User
@@ -1129,6 +1130,21 @@ class TestFilenameGeneration(DirectoriesMixin, TestCase):
 
         self.assertEqual(generate_filename(owned_doc), "user1/The Title.pdf")
         self.assertEqual(generate_filename(no_owner_doc), "none/does matter.pdf")
+
+    @override_settings(
+        FILENAME_FORMAT="{title}",
+    )
+    def test_generate_shorted_file_name(self):
+        doc = Document.objects.create(
+            mime_type="application/pdf",
+            title="This file has a very long filename that will exceed filename limits on some obscure filesystems, such as eCryptfs which accepts up to 143 characters",
+            checksum="3",
+        )
+        self.assertEqual(len(generate_filename(doc)), 152)
+        self.assertLessEqual(len(generate_filename(doc, basename_max_length=120)), 143)
+        self.assertLessEqual(len(generate_filename(doc, basename_max_length=15)), 38)
+        with pytest.raises(ValueError):
+            generate_filename(doc, basename_max_length=14)
 
     @override_settings(
         FILENAME_FORMAT="{original_name}",


### PR DESCRIPTION
Some filesystems set a low limit for filename, eg: 143 characters for eCryptfs. This is still used in some systems, such as Synology and QNAP NAS devices when using encrypted folders.

The document exporter will try to warn the user if the filesystem has such a limit. The user can also set a limit with the parameter "--max_filename_length".

<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

<!--
Please include a summary of the change and which issue is fixed (if any) and any relevant motivation / context. List any dependencies that are required for this change. If appropriate, please include an explanation of how your proposed change can be tested. Screenshots and / or videos can also be helpful if appropriate.
-->

<!--
⚠️ Important: Pull requests that implement a new feature or enhancement *should almost always target an existing feature request* with evidence of community interest and discussion. This is in order to balance the work of implementing and maintaining new features / enhancements. If that is not currently the case, please open a feature request instead of this PR to gather feedback from both users and the project maintainers.
-->

Closes #(issue or discussion)

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [ ] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [ ] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [ ] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [ ] I have made corresponding changes to the documentation as needed.
- [ ] I have checked my modifications for any breaking changes.
