### PR TITLE
[Do not merge] Add django-cachalot as database ORM read cache

### DIFF
--- a/docs/administration.md
+++ b/docs/administration.md
@@ -460,6 +460,19 @@ of the index and usually makes queries faster and also ensures that the
 autocompletion works properly. This command is regularly invoked by the
 task scheduler.
 
+### Clearing the database read cache
+
+If the database read cache is enabled, **you must run this command** after making any changes to the database outside the application context.
+This includes operations such as restoring a database backup or executing SQL statements like UPDATE, INSERT, DELETE, ALTER, CREATE, or DROP.
+
+Failing to invalidate the cache after such modifications can lead to stale data being served from the cache, and **may cause data corruption** or inconsistent behavior in the application.
+
+Use the following management command to clear the cache:
+
+```
+invalidate_db_cache
+```
+
 ### Managing filenames {#renamer}
 
 If you use paperless' feature to

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -157,6 +157,43 @@ to postgresql if you are having concurrency problems with sqlite.
 
     Defaults to unset, keeping the Django defaults.
 
+#### [`PAPERLESS_DB_READ_CACHE_ENABLED=<bool>`](#PAPERLESS_DB_READ_CACHE_ENABLED) {#PAPERLESS_DB_READ_CACHE_ENABLED}
+
+: Enables the database read cache using Redis. This can significantly improve application response times by caching database queries, at the cost of increased memory usage.
+
+    Defaults to `false`.
+
+    !!! danger
+
+    **Do not modify the database outside the application while it is running.**
+    This includes actions such as restoring a backup, upgrading the database, or performing manual inserts. All external modifications must be done **only when the application is stopped**.
+    After making any such changes, you **must invalidate the DB read cache** using the `invalidate_db_cache` management command.
+
+#### [`PAPERLESS_DB_READ_CACHE_TTL=<int>`](#PAPERLESS_DB_READ_CACHE_TTL) {#PAPERLESS_DB_READ_CACHE_TTL}
+
+: Specifies how long (in seconds) database query results should be cached.
+
+    Defaults to `3600` (one hour).
+    Requires `PAPERLESS_DB_READ_CACHE_ENABLED` to be set to `true`.
+
+    !!! warning
+
+    A high TTL increases memory usage over time.
+
+In case of an out-of-memory (OOM) situation, Redis may stop accepting new data—including DB cache entries, scheduled tasks, and documents to consume.
+If your system has limited RAM, consider configuring a dedicated Redis instance for the DB read cache, with a memory limit and the eviction policy set to `allkeys-lru`.
+For more details, refer to the [Redis eviction policy documentation](https://redis.io/docs/latest/develop/reference/eviction/), and see the `PAPERLESS_DB_READ_CACHE_REDIS_URL` setting to specify a separate Redis broker.
+
+#### [`PAPERLESS_DB_READ_CACHE_REDIS_URL=<url>`](#PAPERLESS_DB_READ_CACHE_REDIS_URL) {#PAPERLESS_DB_READ_CACHE_REDIS_URL}
+
+: Defines the Redis instance used for the database read cache.
+
+    Defaults to `None`.
+    Requires `PAPERLESS_DB_READ_CACHE_ENABLED` to be set to `true`.
+
+    !!! Note
+    If this value is not set, the same Redis instance used for scheduled tasks will be used for caching as well.
+
 ## Optional Services
 
 ### Tika {#tika}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
   "django~=5.1.7",
   "django-allauth[socialaccount,mfa]~=65.4.0",
   "django-auditlog~=3.0.0",
+  "django-cachalot~=2.8.0",
   "django-celery-results~=2.6.0",
   "django-compression-middleware~=0.5.0",
   "django-cors-headers~=4.7.0",

--- a/src/documents/management/commands/invalidate_db_cache.py
+++ b/src/documents/management/commands/invalidate_db_cache.py
@@ -1,0 +1,23 @@
+from django.core.management.base import BaseCommand
+
+from paperless.db_cache import CacheManager
+
+
+class Command(BaseCommand):
+    help = "This will clear the database read cache."
+
+    def handle(self, *args, **options):
+        verbosity = int(options["verbosity"])
+        if verbosity > 0:
+            self.stdout.write("Clearing cache...")
+
+        try:
+            deleted_keys = CacheManager().invalidate_cache()
+            if verbosity > 0:
+                self.stdout.write(
+                    f"Database read cache successfully invalidated ({deleted_keys} keys deleted).",
+                )
+
+        except Exception as e:
+            self.stdout.write("Error: Could not clear the cache.")
+            raise e

--- a/src/documents/tests/test_management.py
+++ b/src/documents/tests/test_management.py
@@ -256,3 +256,21 @@ class TestPruneAuditLogs(TestCase):
         call_command("prune_audit_logs")
 
         self.assertEqual(LogEntry.objects.count(), 0)
+
+
+class TestInvalidateDBCache(TestCase):
+    @mock.patch("paperless.db_cache.CacheManager.invalidate_cache")
+    def test_invalidate_db_cache(self, m):
+        call_command("invalidate_db_cache")
+
+        m.assert_called_once()
+
+    @mock.patch("paperless.db_cache.CacheManager.invalidate_cache")
+    def test_invalidate_db_cache_error(self, m):
+        m.side_effect = Exception("Cache invalidation error")
+
+        with self.assertRaises(Exception) as context:
+            call_command("invalidate_db_cache")
+
+        self.assertEqual(str(context.exception), "Cache invalidation error")
+        m.assert_called_once()

--- a/src/paperless/db_cache.py
+++ b/src/paperless/db_cache.py
@@ -1,5 +1,3 @@
-"""Database caching utilities."""
-
 import redis
 from cachalot.utils import get_query_cache_key
 from cachalot.utils import get_table_cache_key
@@ -7,7 +5,7 @@ from django.core.cache import cache
 
 from paperless import settings
 
-PREFIX = "cachalot_"
+PREFIX = "pngx_cachalot_"
 
 
 def custom_get_query_cache_key(compiler):
@@ -24,10 +22,11 @@ def _cache_key_prefix():
 
 class CacheManager:
     def __init__(self):
-        if "cachalot" in settings.INSTALLED_APPS:
-            self.redis_instance = redis.from_url(settings.CACHALOT_REDIS_URL)
-        else:
-            self.redis_instance = None
+        self.redis_instance = (
+            redis.from_url(settings.CACHALOT_REDIS_URL)
+            if "cachalot" in settings.INSTALLED_APPS
+            else None
+        )
 
     def invalidate_cache(self, prefix=_cache_key_prefix(), chunk_size=1000) -> int:
         deleted_keys = 0

--- a/src/paperless/db_cache.py
+++ b/src/paperless/db_cache.py
@@ -1,0 +1,40 @@
+"""Database caching utilities."""
+
+import redis
+from cachalot.utils import get_query_cache_key
+from cachalot.utils import get_table_cache_key
+from django.core.cache import cache
+
+from paperless import settings
+
+PREFIX = "cachalot_"
+
+
+def custom_get_query_cache_key(compiler):
+    return PREFIX + get_query_cache_key(compiler)
+
+
+def custom_get_table_cache_key(db_alias, table):
+    return PREFIX + get_table_cache_key(db_alias, table)
+
+
+def _cache_key_prefix():
+    return cache.make_key(PREFIX)
+
+
+class CacheManager:
+    def __init__(self):
+        if "cachalot" in settings.INSTALLED_APPS:
+            self.redis_instance = redis.from_url(settings.CACHALOT_REDIS_URL)
+        else:
+            self.redis_instance = None
+
+    def invalidate_cache(self, prefix=_cache_key_prefix(), chunk_size=1000) -> int:
+        deleted_keys = 0
+        if self.redis_instance:
+            # Delete all Redis keys related to Cachalot
+            for key in self.redis_instance.scan_iter(f"{prefix}*", count=chunk_size):
+                self.redis_instance.delete(key)
+                deleted_keys += 1
+
+        return deleted_keys

--- a/src/paperless/settings.py
+++ b/src/paperless/settings.py
@@ -896,6 +896,25 @@ if DEBUG and os.getenv("PAPERLESS_CACHE_BACKEND") is None:
         "django.core.cache.backends.locmem.LocMemCache"  # pragma: no cover
     )
 
+# Cachalot: Database read cache. Supports Redis backend only.
+if __get_boolean("PAPERLESS_DB_READ_CACHE_ENABLED"):
+    INSTALLED_APPS.append("cachalot")
+
+_, CACHALOT_REDIS_URL = _parse_redis_url(
+    os.getenv("PAPERLESS_DB_READ_CACHE_REDIS_URL", None),
+)
+CACHALOT_REDIS_PREFIX = os.getenv("PAPERLESS_DB_READ_CACHE_REDIS_PREFIX", "")
+CACHES["cachalot"] = {
+    "BACKEND": "django.core.cache.backends.redis.RedisCache",
+    "LOCATION": CACHALOT_REDIS_URL,
+    "KEY_PREFIX": CACHALOT_REDIS_PREFIX,
+}
+CACHALOT_CACHE = "cachalot"
+CACHALOT_TIMEOUT = __get_int("PAPERLESS_DB_READ_CACHE_TTL", 3600)
+CACHALOT_QUERY_KEYGEN = "paperless.db_cache.custom_get_query_cache_key"
+CACHALOT_TABLE_KEYGEN = "paperless.db_cache.custom_get_table_cache_key"
+CACHALOT_FINAL_SQL_CHECK = True
+
 
 def default_threads_per_worker(task_workers) -> int:
     # always leave one core open

--- a/src/paperless/tests/test_db_cache.py
+++ b/src/paperless/tests/test_db_cache.py
@@ -1,0 +1,65 @@
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+from paperless.db_cache import CacheManager
+from paperless.db_cache import _cache_key_prefix
+from paperless.db_cache import custom_get_query_cache_key
+from paperless.db_cache import custom_get_table_cache_key
+
+
+@patch("paperless.db_cache.get_query_cache_key")
+def test_custom_get_query_cache_key(mock_get_query_cache_key):
+    mock_get_query_cache_key.return_value = "query_key"
+    result = custom_get_query_cache_key(MagicMock())
+    assert result == "pngx_cachalot_query_key"
+    mock_get_query_cache_key.assert_called_once()
+
+
+@patch("paperless.db_cache.get_table_cache_key")
+def test_custom_get_table_cache_key(mock_get_table_cache_key):
+    mock_get_table_cache_key.return_value = "table_key"
+    db_alias = "default"
+    table = "test_table"
+    result = custom_get_table_cache_key(db_alias, table)
+    assert result == "pngx_cachalot_table_key"
+    mock_get_table_cache_key.assert_called_once_with(db_alias, table)
+
+
+@patch("django.core.cache.cache.make_key")
+def test_cache_key_prefix(mock_make_key):
+    mock_make_key.return_value = "pngx_cachalot_"
+    result = _cache_key_prefix()
+    assert result == "pngx_cachalot_"
+
+
+@patch("paperless.db_cache.redis.from_url")
+@patch("paperless.db_cache.settings")
+def test_cache_manager_init_with_cachalot(mock_settings, mock_redis_from_url):
+    mock_settings.INSTALLED_APPS = ["cachalot"]
+    mock_settings.CACHALOT_REDIS_URL = "redis://localhost:6379/0"
+    mock_redis_instance = MagicMock()
+    mock_redis_from_url.return_value = mock_redis_instance
+
+    cache_manager = CacheManager()
+
+    assert cache_manager.redis_instance == mock_redis_instance
+    mock_redis_from_url.assert_called_once_with("redis://localhost:6379/0")
+
+
+@patch("paperless.db_cache.redis.from_url")
+@patch("paperless.db_cache.settings")
+@patch("paperless.db_cache._cache_key_prefix")
+def test_invalidate_cache(mock_cache_key_prefix, mock_settings, mock_redis_from_url):
+    mock_settings.INSTALLED_APPS = ["cachalot"]
+    mock_settings.CACHALOT_REDIS_URL = "redis://localhost:6379/0"
+    mock_cache_key_prefix.return_value = "pngx_cachalot_"
+    mock_redis_instance = MagicMock()
+    mock_redis_instance.scan_iter.return_value = ["key1", "key2"]
+    mock_redis_from_url.return_value = mock_redis_instance
+
+    cache_manager = CacheManager()
+    deleted_keys = cache_manager.invalidate_cache()
+
+    assert deleted_keys == 2
+    mock_redis_instance.delete.assert_any_call("key1")
+    mock_redis_instance.delete.assert_any_call("key2")

--- a/uv.lock
+++ b/uv.lock
@@ -672,6 +672,18 @@ wheels = [
 ]
 
 [[package]]
+name = "django-cachalot"
+version = "2.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "django", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f5/53/1f781e58028a43028d6c799f2eab15eff65e841e3e288d6f2953e36f01a4/django_cachalot-2.8.0.tar.gz", hash = "sha256:30456720ac9f3fabeb90ce898530fe01130c25a1eca911cd016cfaeab251d627", size = 74673 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/05/f5846fd186189ac0a1deddb9c67450c838e5c8ceceb35b5260c61f622599/django_cachalot-2.8.0-py3-none-any.whl", hash = "sha256:315da766a5356c7968318326f7b0579f64571ad909f64cad0601f38153ca4e16", size = 55671 },
+]
+
+[[package]]
 name = "django-celery-results"
 version = "2.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1892,6 +1904,7 @@ dependencies = [
     { name = "django", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "django-allauth", extra = ["mfa", "socialaccount"], marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "django-auditlog", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "django-cachalot", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "django-celery-results", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "django-compression-middleware", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "django-cors-headers", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
@@ -2022,6 +2035,7 @@ requires-dist = [
     { name = "django", specifier = "~=5.1.7" },
     { name = "django-allauth", extras = ["socialaccount", "mfa"], specifier = "~=65.4.0" },
     { name = "django-auditlog", specifier = "~=3.0.0" },
+    { name = "django-cachalot", specifier = "~=2.8.0" },
     { name = "django-celery-results", specifier = "~=2.6.0" },
     { name = "django-compression-middleware", specifier = "~=0.5.0" },
     { name = "django-cors-headers", specifier = "~=4.7.0" },


### PR DESCRIPTION
DB queries made by the Django ORM are now cached in Redis with django-cachalot.

Limitations:
- When Redis is not available (eg: debug mode with local memory cache), the read cache is disabled.
- Whenever a row is modified by a django application (Paperless, Celery...), the whole table is removed from the cache (Limitation of django-cachalot).
- /!\ WARNING: If you modify the database through a `python manage.py` command or externally, you must invalidate the cache with `python manage.py invalidate_db_cache`.

<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->

## Proposed change

<!--
Please include a summary of the change and which issue is fixed (if any) and any relevant motivation / context. List any dependencies that are required for this change. If appropriate, please include an explanation of how your proposed change can be tested. Screenshots and / or videos can also be helpful if appropriate.
-->

<!--
⚠️ Important: Pull requests that implement a new feature or enhancement *should almost always target an existing feature request* with evidence of community interest and discussion. This is in order to balance the work of implementing and maintaining new features / enhancements. If that is not currently the case, please open a feature request instead of this PR to gather feedback from both users and the project maintainers.
-->

Closes #(issue or discussion)

## Type of change

<!--
What type of change does your PR introduce to Paperless-ngx?
NOTE: Please check only one box!
-->

- [x] Bug fix: non-breaking change which fixes an issue.
- [ ] New feature / Enhancement: non-breaking change which adds functionality. _Please read the important note above._
- [ ] Breaking change: fix or feature that would cause existing functionality to not work as expected.
- [ ] Documentation only.
- [ ] Other. Please explain:

## Checklist:

<!--
NOTE: PRs that do not address the following will not be merged, please do not skip any relevant items.
-->

- [x] I have read & agree with the [contributing guidelines](https://github.com/paperless-ngx/paperless-ngx/blob/main/CONTRIBUTING.md).
- [ ] If applicable, I have included testing coverage for new code in this PR, for [backend](https://docs.paperless-ngx.com/development/#testing) and / or [front-end](https://docs.paperless-ngx.com/development/#testing-and-code-style) changes.
- [x] If applicable, I have tested my code for new features & regressions on both mobile & desktop devices, using the latest version of major browsers.
- [x] If applicable, I have checked that all tests pass, see [documentation](https://docs.paperless-ngx.com/development/#back-end-development).
- [ ] I have run all `pre-commit` hooks, see [documentation](https://docs.paperless-ngx.com/development/#code-formatting-with-pre-commit-hooks).
- [x] I have made corresponding changes to the documentation as needed.
- [x] I have checked my modifications for any breaking changes.
