### PR TITLE
Replacing Whoosh by Tantivy for advanced search

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ dependencies = [
   "regex>=2025.9.18",
   "scikit-learn~=1.7.0",
   "setproctitle~=1.3.4",
+  "tantivy~=0.25.1",
   "tika-client~=0.10.0",
   "tqdm~=4.67.1",
   "watchdog~=6.0",

--- a/src-ui/src/app/components/admin/config/config.component.html
+++ b/src-ui/src/app/components/admin/config/config.component.html
@@ -19,13 +19,18 @@
                                 <div class="col">
                                     <div class="card bg-light">
                                         <div class="card-body">
-                                            <div class="card-title">
-                                                <h6>
-                                                    {{option.title}}
-                                                    <a class="btn btn-sm btn-link" title="Read the documentation about this setting" i18n-title [href]="getDocsUrl(option.config_key)" target="_blank" referrerpolicy="no-referrer">
-                                                        <i-bs  name="info-circle"></i-bs>
-                                                    </a>
+                                            <div class="card-title d-flex align-items-center">
+                                                <h6 class="mb-0">
+                                                  {{option.title}}
                                                 </h6>
+                                                <a class="btn btn-sm btn-link" title="Read the documentation about this setting" i18n-title [href]="getDocsUrl(option.config_key)" target="_blank" referrerpolicy="no-referrer">
+                                                    <i-bs name="info-circle"></i-bs>
+                                                </a>
+                                                @if (isSet(option.key)) {
+                                                  <button type="button" class="btn btn-sm btn-link text-danger ms-auto pe-0" title="Reset" i18n-title (click)="resetOption(option.key)">
+                                                      <i-bs class="me-1" name="x"></i-bs><ng-container i18n>Reset</ng-container>
+                                                  </button>
+                                                }
                                             </div>
                                             <div class="mb-n3">
                                                 @switch (option.type) {

--- a/src-ui/src/app/components/admin/config/config.component.spec.ts
+++ b/src-ui/src/app/components/admin/config/config.component.spec.ts
@@ -144,4 +144,18 @@ describe('ConfigComponent', () => {
     component.uploadFile(new File([], 'test.png'), 'app_logo')
     expect(initSpy).toHaveBeenCalled()
   })
+
+  it('should reset option to null', () => {
+    component.configForm.patchValue({ output_type: OutputTypeConfig.PDF_A })
+    expect(component.isSet('output_type')).toBeTruthy()
+    component.resetOption('output_type')
+    expect(component.configForm.get('output_type').value).toBeNull()
+    expect(component.isSet('output_type')).toBeFalsy()
+    component.configForm.patchValue({ app_title: 'Test Title' })
+    component.resetOption('app_title')
+    expect(component.configForm.get('app_title').value).toBeNull()
+    component.configForm.patchValue({ barcodes_enabled: true })
+    component.resetOption('barcodes_enabled')
+    expect(component.configForm.get('barcodes_enabled').value).toBeNull()
+  })
 })

--- a/src-ui/src/app/components/admin/config/config.component.ts
+++ b/src-ui/src/app/components/admin/config/config.component.ts
@@ -208,4 +208,12 @@ export class ConfigComponent
         },
       })
   }
+
+  public isSet(key: string): boolean {
+    return this.configForm.get(key).value != null
+  }
+
+  public resetOption(key: string) {
+    this.configForm.get(key).setValue(null)
+  }
 }

--- a/src-ui/src/app/components/manage/management-list/management-list.component.html
+++ b/src-ui/src/app/components/manage/management-list/management-list.component.html
@@ -62,9 +62,9 @@
 
 @if (!loading) {
   <div class="d-flex mb-2">
-    @if (collectionSize > 0) {
+    @if (displayCollectionSize > 0) {
       <div>
-        <ng-container i18n>{collectionSize, plural, =1 {One {{typeName}}} other {{{collectionSize || 0}} total {{typeNamePlural}}}}</ng-container>
+        <ng-container i18n>{displayCollectionSize, plural, =1 {One {{typeName}}} other {{{displayCollectionSize || 0}} total {{typeNamePlural}}}}</ng-container>
         @if (selectedObjects.size > 0) {
           &nbsp;({{selectedObjects.size}} selected)
         }

--- a/src-ui/src/app/components/manage/management-list/management-list.component.spec.ts
+++ b/src-ui/src/app/components/manage/management-list/management-list.component.spec.ts
@@ -229,7 +229,7 @@ describe('ManagementListComponent', () => {
     expect(reloadSpy).toHaveBeenCalled()
   })
 
-  it('should use the all list length for collection size when provided', fakeAsync(() => {
+  it('should use API count for pagination and all ids for displayed total', fakeAsync(() => {
     jest.spyOn(tagService, 'listFiltered').mockReturnValueOnce(
       of({
         count: 1,
@@ -241,7 +241,8 @@ describe('ManagementListComponent', () => {
     component.reloadData()
     tick(100)
 
-    expect(component.collectionSize).toBe(3)
+    expect(component.collectionSize).toBe(1)
+    expect(component.displayCollectionSize).toBe(3)
   }))
 
   it('should support quick filter for objects', () => {

--- a/src-ui/src/app/components/manage/management-list/management-list.component.ts
+++ b/src-ui/src/app/components/manage/management-list/management-list.component.ts
@@ -23,6 +23,7 @@ import {
   MatchingModel,
 } from 'src/app/data/matching-model'
 import { ObjectWithPermissions } from 'src/app/data/object-with-permissions'
+import { Results } from 'src/app/data/results'
 import {
   SortableDirective,
   SortEvent,
@@ -88,6 +89,7 @@ export abstract class ManagementListComponent<T extends MatchingModel>
   public page = 1
 
   public collectionSize = 0
+  public displayCollectionSize = 0
 
   public sortField: string
   public sortReverse: boolean
@@ -141,6 +143,14 @@ export abstract class ManagementListComponent<T extends MatchingModel>
     return data
   }
 
+  protected getCollectionSize(results: Results<T>): number {
+    return results.all?.length ?? results.count
+  }
+
+  protected getDisplayCollectionSize(results: Results<T>): number {
+    return this.getCollectionSize(results)
+  }
+
   getDocumentCount(object: MatchingModel): number {
     return (
       object.document_count ??
@@ -171,7 +181,8 @@ export abstract class ManagementListComponent<T extends MatchingModel>
         tap((c) => {
           this.unfilteredData = c.results
           this.data = this.filterData(c.results)
-          this.collectionSize = c.all?.length ?? c.count
+          this.collectionSize = this.getCollectionSize(c)
+          this.displayCollectionSize = this.getDisplayCollectionSize(c)
         }),
         delay(100)
       )

--- a/src-ui/src/app/components/manage/tag-list/tag-list.component.ts
+++ b/src-ui/src/app/components/manage/tag-list/tag-list.component.ts
@@ -7,6 +7,7 @@ import {
 } from '@ng-bootstrap/ng-bootstrap'
 import { NgxBootstrapIconsModule } from 'ngx-bootstrap-icons'
 import { FILTER_HAS_TAGS_ALL } from 'src/app/data/filter-rule-type'
+import { Results } from 'src/app/data/results'
 import { Tag } from 'src/app/data/tag'
 import { IfPermissionsDirective } from 'src/app/directives/if-permissions.directive'
 import { SortableDirective } from 'src/app/directives/sortable.directive'
@@ -75,6 +76,16 @@ export class TagListComponent extends ManagementListComponent<Tag> {
     // When filtering by name, exclude children if their parent is also present
     const availableIds = new Set(data.map((tag) => tag.id))
     return data.filter((tag) => !tag.parent || !availableIds.has(tag.parent))
+  }
+
+  protected override getCollectionSize(results: Results<Tag>): number {
+    // Tag list pages are requested with is_root=true (when unfiltered), so
+    // pagination must follow root count even though `all` includes descendants
+    return results.count
+  }
+
+  protected override getDisplayCollectionSize(results: Results<Tag>): number {
+    return super.getCollectionSize(results)
   }
 
   protected override getSelectableIDs(tags: Tag[]): number[] {

--- a/src/documents/filters.py
+++ b/src/documents/filters.py
@@ -12,6 +12,7 @@ from django.db.models import Case
 from django.db.models import CharField
 from django.db.models import Count
 from django.db.models import Exists
+from django.db.models import F
 from django.db.models import IntegerField
 from django.db.models import OuterRef
 from django.db.models import Q
@@ -843,6 +844,10 @@ class DocumentsOrderingFilter(OrderingFilter):
     field_name = "ordering"
     prefix = "custom_field_"
 
+    # Fields with nullable ForeignKeys need explicit NULLS LAST for
+    # consistent ordering across database backends (SQLite vs PostgreSQL).
+    _NULLABLE_FIELDS = {"owner"}
+
     def filter_queryset(self, request, queryset, view):
         param = request.query_params.get("ordering")
         if param and self.prefix in param:
@@ -976,5 +981,15 @@ class DocumentsOrderingFilter(OrderingFilter):
                 )
                 .distinct()
             )
+
+        if param:
+            field = param.lstrip("-")
+            if field in self._NULLABLE_FIELDS:
+                descending = param.startswith("-")
+                if descending:
+                    queryset = queryset.order_by(F(field).desc(nulls_first=True))
+                else:
+                    queryset = queryset.order_by(F(field).asc(nulls_last=True))
+                return queryset
 
         return super().filter_queryset(request, queryset, view)

--- a/src/documents/index.py
+++ b/src/documents/index.py
@@ -282,6 +282,8 @@ def update_document(
     doc: Document,
     effective_content: str | None = None,
     viewer_ids: list[int] | None = None,
+    *,
+    skip_delete: bool = False,
 ) -> None:
     if effective_content is None:
         effective_content = doc.content
@@ -312,9 +314,10 @@ def update_document(
         )
         viewer_ids = [int(u.id) for u in users_with_perms]
 
-    writer.delete_documents_by_query(
-        tantivy.Query.term_query(get_schema(), "id", doc.pk),
-    )
+    if not skip_delete:
+        writer.delete_documents_by_query(
+            tantivy.Query.term_query(get_schema(), "id", doc.pk),
+        )
     indexed_doc = tantivy.Document(
         id=doc.pk,
         title=doc.title or "",

--- a/src/documents/index.py
+++ b/src/documents/index.py
@@ -1060,8 +1060,10 @@ class DelayedFullTextQuery(DelayedQuery):
         else:
             fuzzy_search = False
         # TODO: date parsing plugin like whoosh
+
         with open_index() as index:
             queries = list()
+            field_boosts = {"title": 1.5, "notes": 0.8}
             q = index.parse_query_lenient(
                 q_str,
                 [
@@ -1077,7 +1079,7 @@ class DelayedFullTextQuery(DelayedQuery):
                     "created",
                     "modified",
                 ],
-                field_boosts={"title": 5.0, "content": 0.5},
+                field_boosts=field_boosts,
                 conjunction_by_default=True,
             )[0]
             queries.append(q)
@@ -1088,18 +1090,14 @@ class DelayedFullTextQuery(DelayedQuery):
                     q_str,
                     [
                         "content",
-                        "bigram_content",
                         "title",
                         "correspondent",
                         "tag",
                         "type",
                         "notes",
                         "custom_fields",
-                        "added",
-                        "created",
-                        "modified",
                     ],
-                    field_boosts={"title": 3.0, "content": 0.5},
+                    field_boosts=field_boosts,
                     fuzzy_fields={
                         "content": (True, 1, True),
                         "title": (True, 1, True),

--- a/src/documents/index.py
+++ b/src/documents/index.py
@@ -1155,17 +1155,25 @@ class DelayedFullTextQuery(DelayedQuery):
             q = tantivy.Query.boolean_query(
                 [(tantivy.Occur.Should, q) for q in queries],
             )
-            words = autocomplete(
-                index,
-                raw_query,
-                limit=1,
-                user=self.user,
-                fuzzy_search=True,
-            )
-            top_word = words[0].decode("utf-8") if words else None
-            suggested_correction = (
-                top_word if top_word and top_word != raw_query else None
-            )
+            try:
+                words = autocomplete(
+                    index,
+                    raw_query,
+                    limit=1,
+                    user=self.user,
+                    fuzzy_search=True,
+                )
+                top_word = words[0].decode("utf-8") if words else None
+                suggested_correction = (
+                    top_word if top_word and top_word != raw_query else None
+                )
+            except Exception as e:
+                suggested_correction = None
+                logger.info(
+                    "Error while correcting query %s: %s",
+                    f"{raw_query!r}",
+                    e,
+                )
 
         return q, suggested_correction
 

--- a/src/documents/index.py
+++ b/src/documents/index.py
@@ -1293,7 +1293,7 @@ def get_permissions_query(user: User | None, schema) -> tantivy.Query:
         return tantivy.Query.all_query()
 
     # Always return documents with no owner
-    queries = [tantivy.Query.term_query(schema, "has_owner", "false")]
+    queries = [tantivy.Query.term_query(schema, "has_owner", False)]
 
     if user:
         user_id = str(user.id)

--- a/src/documents/index.py
+++ b/src/documents/index.py
@@ -346,9 +346,7 @@ def update_document(
         viewer_ids = [int(u.id) for u in users_with_perms]
 
     if not skip_delete:
-        writer.delete_documents_by_query(
-            tantivy.Query.term_query(get_schema(), "id", doc.pk),
-        )
+        remove_document(writer, doc)
     indexed_doc = tantivy.Document(
         id=doc.pk,
         title=doc.title or "",

--- a/src/documents/index.py
+++ b/src/documents/index.py
@@ -38,7 +38,6 @@ if TYPE_CHECKING:
     from whoosh.searching import ResultsPage
 
 logger = logging.getLogger("paperless.index")
-index_dir = f"{settings.INDEX_DIR}_tantivy"
 
 CJK_RE = re.compile(r"[\u4e00-\u9fff\u3040-\u30ff\uac00-\ud7af]+")
 WORD_RE = re.compile(r"\w+", flags=re.IGNORECASE)
@@ -151,21 +150,27 @@ def get_schema():
     return sb.build()
 
 
-def create_index_dir(path=index_dir):
+def _get_index_dir():
+    return f"{settings.INDEX_DIR}_tantivy"
+
+
+def create_index_dir(path=None):
     """Create the Tantivy index directory if it doesn't exist."""
-    Path(path).mkdir(parents=True, exist_ok=True)
+    Path(path or _get_index_dir()).mkdir(parents=True, exist_ok=True)
 
 
-def recreate_index_dir(path=index_dir):
+def recreate_index_dir(path=None):
     """Clear the Tantivy index by deleting and recreating its directory."""
+    path = path or _get_index_dir()
     rmtree(path)
     create_index_dir(path)
 
 
 @contextmanager
-def open_index(*, recreate=False, reload=True, path=index_dir):
+def open_index(*, recreate=False, reload=True, path=None):
     import time as stime
 
+    path = path or _get_index_dir()
     if not Path(path).exists():
         create_index_dir(path)
     elif recreate:
@@ -973,18 +978,6 @@ def preprocess_query_dates(query: str, date_fields=DATE_FIELDS) -> str:
 NQL_TOKENS = ["AND", "OR", "NOT", "TO", "+", "-", "(", ")", '"', "[", "]"]
 
 
-def rewrite_default_and_keywords(query_string: str) -> str:
-    """
-    Separate keywords by AND when natural query language isn't detected.
-    """
-    if not any(
-        [w in query_string for w in NQL_TOKENS],
-    ):
-        # No natural language detected, so separate by AND
-        query_string = re.sub(r"\s+", " AND ", query_string.strip())
-    return query_string
-
-
 # Known keywords in your search syntax
 KEYWORDS = [
     "content",
@@ -1080,10 +1073,9 @@ def preprocess_query(query: str) -> tuple[str, list[str]]:
     1. rewrite_natural_date_keywords: today/yesterday/this month… → UTC ISO ranges
     2. normalize_query: comma-separated parts → AND joins
     3. preprocess_query_dates: remaining date expressions (Whoosh parser) → ISO ranges
-    4. extract_query_parts: extract free text terms (for fuzzy search decision)
 
     Returns:
-        (rewritten_query, text_terms)
+        The rewritten query string, ready for Tantivy's parse_query_lenient.
     """
     logger.debug(f"raw query: {query}")
     query = rewrite_natural_date_keywords(query)
@@ -1092,17 +1084,18 @@ def preprocess_query(query: str) -> tuple[str, list[str]]:
     logger.debug(f"after normalize: {query}")
     query = preprocess_query_dates(query)
     logger.debug(f"after date preprocessing: {query}")
-    text_terms = extract_query_parts(query)["text_terms"]
-    logger.debug(f"text terms: {text_terms}")
-    return query, text_terms
+    return query
 
 
 class DelayedFullTextQuery(DelayedQuery):
     def _get_query(self) -> tuple:
-        q_str, text_terms = preprocess_query(self.query_params["query"])
+        q_str = preprocess_query(self.query_params["query"])
 
         if settings.ADVANCED_FUZZY_SEARCH_TRESHOLD and any(
-            [len(t) >= settings.ADVANCED_FUZZY_SEARCH_TRESHOLD for t in text_terms],
+            [
+                len(t) >= settings.ADVANCED_FUZZY_SEARCH_TRESHOLD
+                for t in extract_query_parts(q_str)["text_terms"]
+            ],
         ):
             fuzzy_search = True
         else:

--- a/src/documents/index.py
+++ b/src/documents/index.py
@@ -1241,7 +1241,7 @@ def autocomplete(
                 prefix_subquery = tantivy.Query.regex_query(
                     schema,
                     "autocomplete_word",
-                    f"{normalized_term}.*",
+                    f"{re.escape(normalized_term)}.*",
                 )
         except ValueError as e:
             # Autocomplete doesn't support special terms, e.g. parentheses, +, - etc.

--- a/src/documents/index.py
+++ b/src/documents/index.py
@@ -1,173 +1,297 @@
 from __future__ import annotations
 
+import bisect
 import logging
 import math
+import os
 import re
-from collections import Counter
+import threading
+import unicodedata
+from collections import defaultdict
 from contextlib import contextmanager
 from datetime import datetime
 from datetime import time
 from datetime import timedelta
 from datetime import timezone
+from functools import lru_cache
+from pathlib import Path
 from shutil import rmtree
-from time import sleep
 from typing import TYPE_CHECKING
 from typing import Literal
 
+import tantivy
 from dateutil.relativedelta import relativedelta
 from django.conf import settings
 from django.utils import timezone as django_timezone
 from django.utils.timezone import get_current_timezone
 from django.utils.timezone import now
 from guardian.shortcuts import get_users_with_perms
-from whoosh import classify
-from whoosh import highlight
-from whoosh import query
-from whoosh.fields import BOOLEAN
-from whoosh.fields import DATETIME
-from whoosh.fields import KEYWORD
-from whoosh.fields import NUMERIC
-from whoosh.fields import TEXT
-from whoosh.fields import Schema
-from whoosh.highlight import HtmlFormatter
-from whoosh.idsets import BitSet
-from whoosh.idsets import DocIdSet
-from whoosh.index import FileIndex
-from whoosh.index import LockError
-from whoosh.index import create_in
-from whoosh.index import exists_in
-from whoosh.index import open_dir
-from whoosh.qparser import MultifieldParser
-from whoosh.qparser import QueryParser
 from whoosh.qparser.dateparse import DateParserPlugin
 from whoosh.qparser.dateparse import English
-from whoosh.qparser.plugins import FieldsPlugin
-from whoosh.scoring import TF_IDF
 from whoosh.util.times import timespan
-from whoosh.writing import AsyncWriter
 
-from documents.models import CustomFieldInstance
 from documents.models import Document
-from documents.models import Note
 from documents.models import User
 
 if TYPE_CHECKING:
     from django.db.models import QuerySet
-    from whoosh.reading import IndexReader
     from whoosh.searching import ResultsPage
-    from whoosh.searching import Searcher
 
 logger = logging.getLogger("paperless.index")
+index_dir = f"{settings.INDEX_DIR}_tantivy"
+
+CJK_RE = re.compile(r"[\u4e00-\u9fff\u3040-\u30ff\uac00-\ud7af]+")
+WORD_RE = re.compile(r"\w+", flags=re.IGNORECASE)
+
+MAX_RESULT_LIMIT = 1001
 
 
-def get_schema() -> Schema:
-    return Schema(
-        id=NUMERIC(stored=True, unique=True),
-        title=TEXT(sortable=True),
-        content=TEXT(),
-        asn=NUMERIC(sortable=True, signed=False),
-        correspondent=TEXT(sortable=True),
-        correspondent_id=NUMERIC(),
-        has_correspondent=BOOLEAN(),
-        tag=KEYWORD(commas=True, scorable=True, lowercase=True),
-        tag_id=KEYWORD(commas=True, scorable=True),
-        has_tag=BOOLEAN(),
-        type=TEXT(sortable=True),
-        type_id=NUMERIC(),
-        has_type=BOOLEAN(),
-        created=DATETIME(sortable=True),
-        modified=DATETIME(sortable=True),
-        added=DATETIME(sortable=True),
-        path=TEXT(sortable=True),
-        path_id=NUMERIC(),
-        has_path=BOOLEAN(),
-        notes=TEXT(),
-        num_notes=NUMERIC(sortable=True, signed=False),
-        custom_fields=TEXT(),
-        custom_field_count=NUMERIC(sortable=True, signed=False),
-        has_custom_fields=BOOLEAN(),
-        custom_fields_id=KEYWORD(commas=True),
-        owner=TEXT(),
-        owner_id=NUMERIC(),
-        has_owner=BOOLEAN(),
-        viewer_id=KEYWORD(commas=True),
-        checksum=TEXT(),
-        page_count=NUMERIC(sortable=True),
-        original_filename=TEXT(sortable=True),
-        is_shared=BOOLEAN(),
+def extract_bigram_content(text: str) -> str:
+    """
+    Extract relevant bigrams from a given text.
+
+    This is used for languages that cannot be properly indexed with simple tokenizer,
+    such as CJK languages.
+    """
+    cjk_sequences = CJK_RE.findall(text)
+    return " ".join(cjk_sequences)
+
+
+# In Tantivy, a text analyzer is a pipeline of
+# a tokenizer, optionally followed by filters.
+bigram_analyzer: tantivy.TextAnalyzer = (
+    tantivy.TextAnalyzerBuilder(
+        tantivy.Tokenizer.ngram(2, 2),
     )
+    .filter(tantivy.Filter.lowercase())
+    .build()
+)
+
+# Remove words longer than 64 characters, make the fields case AND diacritic insensitive
+simple_analyzer: tantivy.TextAnalyzer = (
+    tantivy.TextAnalyzerBuilder(
+        tantivy.Tokenizer.simple(),
+    )
+    .filter(tantivy.Filter.remove_long(65))
+    .filter(tantivy.Filter.lowercase())
+    .filter(tantivy.Filter.ascii_fold())
+    .build()
+)
 
 
-def open_index(*, recreate=False) -> FileIndex:
-    transient_exceptions = (FileNotFoundError, LockError)
-    max_retries = 3
-    retry_delay = 0.1
+@lru_cache(maxsize=1)
+def get_schema():
+    """
+    Prepare the Tantivy index schema.
 
-    for attempt in range(max_retries + 1):
+    index_options: for text fields. "position" is default (frequency and position), "frequency" or "basic".
+    stored: whether the field is stored and can be retrieved directly.
+    fast: whether the field is stored in a columnar fashion, needed for sorting.
+    indexed: needed for integer fields to be searchable.
+    """
+    sb = tantivy.SchemaBuilder()
+    # TODO are all the has_ really needed?
+    sb.add_integer_field("id", stored=True, indexed=True)
+    sb.add_text_field("title", stored=True, fast=True, index_option="basic")
+    sb.add_text_field(
+        "autocomplete_word",
+        stored=True,
+        index_option="basic",
+        tokenizer_name="simple_analyzer",
+    )  # Alphabetically sorted list
+    sb.add_text_field("content", stored=True, tokenizer_name="simple_analyzer")
+    sb.add_text_field(
+        "bigram_content",
+        tokenizer_name="bigram_analyzer",
+        index_option="freq",
+    )  # used for languages such as CJK
+    sb.add_integer_field("asn", stored=True, fast=True)
+    sb.add_text_field("correspondent", stored=True, fast=True, tokenizer_name="default")
+    sb.add_integer_field("correspondent_id", stored=True)
+    sb.add_boolean_field("has_correspondent", stored=True)
+    sb.add_text_field("tag", stored=True, tokenizer_name="simple_analyzer")
+    sb.add_integer_field("tag_id", stored=True)
+    sb.add_boolean_field("has_tag", stored=True)
+    sb.add_text_field("type", stored=True, fast=True, tokenizer_name="default")
+    sb.add_integer_field("type_id", stored=True)
+    sb.add_boolean_field("has_type", stored=True)
+    sb.add_date_field(
+        "created",
+        stored=True,
+        fast=True,
+        indexed=True,
+    )  # Indexed dates must be timezone-naive datetimes
+    sb.add_date_field("modified", stored=True, fast=True, indexed=True)
+    sb.add_date_field("added", stored=True, fast=True, indexed=True)
+    sb.add_text_field("path", stored=True)
+    sb.add_integer_field("path_id", stored=True)
+    sb.add_boolean_field("has_path", stored=True)
+    sb.add_text_field("notes", stored=True, tokenizer_name="simple_analyzer")
+    sb.add_integer_field("num_notes", stored=True, fast=True)
+    sb.add_text_field("custom_fields", stored=True, tokenizer_name="simple_analyzer")
+    sb.add_integer_field("custom_field_count", stored=True)
+    sb.add_integer_field("custom_fields_id", stored=True)
+    sb.add_boolean_field("has_custom_fields", stored=True)
+    sb.add_text_field("owner", stored=True, fast=True)
+    sb.add_integer_field("owner_id", stored=True, indexed=True)
+    sb.add_boolean_field("has_owner", indexed=True)
+    sb.add_integer_field("viewer_id", stored=True, indexed=True)
+    sb.add_text_field("checksum", stored=True, index_option="basic")
+    sb.add_integer_field("page_count", stored=True, fast=True)
+    sb.add_text_field("original_filename", stored=True)
+    sb.add_boolean_field("is_shared", stored=True)
+    return sb.build()
+
+
+def recreate_index_dir(path=index_dir):
+    if Path(path).exists():
+        rmtree(path)
+    Path(path).mkdir(parents=True, exist_ok=True)
+
+
+@contextmanager
+def open_index(*, recreate=False, reload=True):
+    path = index_dir
+    if recreate or not Path(path).exists():
+        recreate_index_dir(path)
+    try:
+        index = tantivy.Index(schema=get_schema(), path=path)
+        index.register_tokenizer("bigram_analyzer", bigram_analyzer)
+        index.register_tokenizer("simple_analyzer", simple_analyzer)
+    except ValueError as e:
+        # Schema has changed
+        logger.warning(f"Recreating index due to error: {e}")
+        recreate_index_dir(path)
+        index = tantivy.Index(schema=get_schema(), path=path)
+    if reload:
+        index.reload()  # Ensure we have the latest commit?
+    yield index
+
+
+class AsyncWriter(threading.Thread):
+    LOCK_EXC_MSG = "Failed to acquire Lockfile"
+
+    def __init__(self, index: tantivy.Index, delay=0.25, **writerargs):
+        """
+        Asynchronous writer for tantivy, inspired from Whoosh's AsyncWriter.
+
+        :param index: the :class:`whoosh.index.Index` to write to.
+        :param delay: the delay (in seconds) between attempts to instantiate
+            the actual writer.
+        :param writerargs: an optional dictionary specifying keyword arguments
+            to to be passed to the index's ``writer()`` method.
+        """
+        threading.Thread.__init__(self)
+        self.running = False
+        self.index = index
+        self.writerargs = writerargs or {}
+        self.delay = delay
+        self.events = []
         try:
-            if exists_in(settings.INDEX_DIR) and not recreate:
-                return open_dir(settings.INDEX_DIR, schema=get_schema())
-            break
-        except transient_exceptions as exc:
-            is_last_attempt = attempt == max_retries or recreate
-            if is_last_attempt:
-                logger.exception(
-                    "Error while opening the index after retries, recreating.",
-                )
-                break
+            self.writer = self.index.writer(**self.writerargs)
+        except ValueError as e:
+            if self.LOCK_EXC_MSG in str(e):
+                self.writer = None
+            else:
+                raise
 
-            logger.warning(
-                "Transient error while opening the index (attempt %s/%s): %s. Retrying.",
-                attempt + 1,
-                max_retries + 1,
-                exc,
-            )
-            sleep(retry_delay)
-        except Exception:
-            logger.exception("Error while opening the index, recreating.")
-            break
+    def _record(self, method, *args, **kwargs):
+        if self.writer:
+            getattr(self.writer, method)(*args, **kwargs)
+        else:
+            self.events.append((method, args, kwargs))
 
-    # create_in doesn't handle corrupted indexes very well, remove the directory entirely first
-    if settings.INDEX_DIR.is_dir():
-        rmtree(settings.INDEX_DIR)
-    settings.INDEX_DIR.mkdir(parents=True, exist_ok=True)
+    def run(self):
+        self.running = True
+        writer = self.writer
+        while writer is None:
+            try:
+                writer = self.index.writer(**self.writerargs)
+            except ValueError as e:
+                if self.LOCK_EXC_MSG in str(e):
+                    import time as stime
 
-    return create_in(settings.INDEX_DIR, get_schema())
+                    stime.sleep(self.delay)
+                else:
+                    raise
+        for method, args, kwargs in self.events:
+            getattr(writer, method)(*args, **kwargs)
+        writer.commit(*self.commitargs, **self.commitkwargs)
+        writer.wait_merging_threads()
+
+    def delete_documents_by_query(self, *args, **kwargs):
+        self._record("delete_documents_by_query", *args, **kwargs)
+
+    def add_document(self, *args, **kwargs):
+        self._record("add_document", *args, **kwargs)
+
+    def commit_and_wait_merging_threads(self, *args, **kwargs):
+        if self.writer:
+            self.writer.commit(*args, **kwargs)
+            self.writer.wait_merging_threads()
+        else:
+            self.commitargs, self.commitkwargs = args, kwargs
+            self.start()
+        if self.is_alive():
+            self.join()
+
+    def rollback(self, *args, **kwargs):
+        if self.writer:
+            return self.writer.rollback(*args, **kwargs)
+        # If we never acquired the writer, drop buffered events
+        self.events.clear()
+        # If a background thread is running, we can't reliably abort tantivy's writer
+        # but dropping events is the best effort here.
 
 
 @contextmanager
-def open_index_writer(*, optimize=False) -> AsyncWriter:
-    writer = AsyncWriter(open_index())
-
-    try:
-        yield writer
-    except Exception as e:
-        logger.exception(str(e))
-        writer.cancel()
-    finally:
-        writer.commit(optimize=optimize)
+def open_index_writer(*, reload=True, **kwargs):
+    with open_index(reload=reload) as index:
+        writer = AsyncWriter(index, num_threads=os.cpu_count() or 0)
+        try:
+            yield writer
+        except Exception as e:
+            logger.exception(str(e))
+            writer.rollback()
+        finally:
+            writer.commit_and_wait_merging_threads()
 
 
 @contextmanager
-def open_index_searcher() -> Searcher:
-    searcher = open_index().searcher()
-
-    try:
-        yield searcher
-    finally:
-        searcher.close()
+def open_index_searcher():
+    with open_index() as index:
+        index.config_reader(reload_policy="commit")
+        yield index.searcher()
 
 
-def update_document(writer: AsyncWriter, doc: Document) -> None:
-    tags = ",".join([t.name for t in doc.tags.all()])
-    tags_ids = ",".join([str(t.id) for t in doc.tags.all()])
-    notes = ",".join([str(c.note) for c in Note.objects.filter(document=doc)])
-    custom_fields = ",".join(
-        [str(c) for c in CustomFieldInstance.objects.filter(document=doc)],
-    )
-    custom_fields_ids = ",".join(
-        [str(f.field.id) for f in CustomFieldInstance.objects.filter(document=doc)],
-    )
+def tokenize_for_autocomplete(text: str):
+    """Return all distinct autocomplete words from a given text."""
+    return {m.group(0).lower() for m in WORD_RE.finditer(text)}
+
+
+def datetime_to_tantivy(dt: datetime | None) -> datetime | None:
+    if dt is None:
+        return None
+    if not isinstance(dt, datetime):
+        raise TypeError(f"Expected datetime, got {type(dt)}")
+    dt = dt.astimezone(timezone.utc).replace(tzinfo=None)
+    return dt
+
+
+def update_document(
+    writer: tantivy.IndexWriter,
+    doc: Document,
+    effective_content: str | None = None,
+) -> None:
+    if effective_content is None:
+        effective_content = doc.content
+    tag_list = list(doc.tags.all())
+    tags = ",".join([t.name for t in tag_list])
+    tags_ids = [t.id for t in tag_list]
+    notes = ",".join([str(n.note) for n in doc.notes.all()])
+    custom_field_list = list(doc.custom_fields.all())
+    custom_fields = ",".join([str(c) for c in custom_field_list])
+    custom_fields_ids = [f.field.id for f in custom_field_list]
     asn: int | None = doc.archive_serial_number
     if asn is not None and (
         asn < Document.ARCHIVE_SERIAL_NUMBER_MIN
@@ -184,51 +308,72 @@ def update_document(writer: AsyncWriter, doc: Document) -> None:
         doc,
         only_with_perms_in=["view_document"],
     )
-    viewer_ids: str = ",".join([str(u.id) for u in users_with_perms])
-    writer.update_document(
+    viewer_ids = [int(u.id) for u in users_with_perms]
+
+    writer.delete_documents_by_query(
+        tantivy.Query.term_query(get_schema(), "id", doc.pk),
+    )
+    indexed_doc = tantivy.Document(
         id=doc.pk,
-        title=doc.title,
-        content=doc.content,
-        correspondent=doc.correspondent.name if doc.correspondent else None,
-        correspondent_id=doc.correspondent.id if doc.correspondent else None,
+        title=doc.title or "",
+        content=effective_content,
+        bigram_content=extract_bigram_content(effective_content),
+        correspondent=doc.correspondent.name if doc.correspondent else "",
+        correspondent_id=doc.correspondent.id if doc.correspondent else 0,
         has_correspondent=doc.correspondent is not None,
-        tag=tags if tags else None,
-        tag_id=tags_ids if tags_ids else None,
         has_tag=len(tags) > 0,
-        type=doc.document_type.name if doc.document_type else None,
-        type_id=doc.document_type.id if doc.document_type else None,
+        type=doc.document_type.name if doc.document_type else "",
+        type_id=doc.document_type.id if doc.document_type else 0,
         has_type=doc.document_type is not None,
-        created=datetime.combine(doc.created, time.min),
-        added=doc.added,
-        asn=asn,
-        modified=doc.modified,
-        path=doc.storage_path.name if doc.storage_path else None,
-        path_id=doc.storage_path.id if doc.storage_path else None,
+        created=datetime_to_tantivy(datetime.combine(doc.created, time.min)),
+        added=datetime_to_tantivy(doc.added),
+        asn=asn or 0,
+        modified=datetime_to_tantivy(doc.modified),
+        path=doc.storage_path.name if doc.storage_path else "",
+        path_id=doc.storage_path.id if doc.storage_path else 0,
         has_path=doc.storage_path is not None,
-        notes=notes,
+        notes=notes or "",
         num_notes=len(notes),
-        custom_fields=custom_fields,
-        custom_field_count=len(doc.custom_fields.all()),
+        custom_fields=custom_fields or "",
+        custom_field_count=len(custom_field_list),
         has_custom_fields=len(custom_fields) > 0,
-        custom_fields_id=custom_fields_ids if custom_fields_ids else None,
-        owner=doc.owner.username if doc.owner else None,
-        owner_id=doc.owner.id if doc.owner else None,
-        has_owner=doc.owner is not None,
-        viewer_id=viewer_ids if viewer_ids else None,
-        checksum=doc.checksum,
-        page_count=doc.page_count,
+        owner=doc.owner.username if doc.owner else "",
+        owner_id=int(doc.owner.id if doc.owner and doc.owner.id else 0),
+        has_owner=bool(doc.owner and doc.owner.id is not None),
+        checksum=doc.checksum or "",
+        page_count=doc.page_count or 0,
         original_filename=doc.original_filename,
         is_shared=len(viewer_ids) > 0,
     )
+    for tag_id in tags_ids:
+        indexed_doc.add_integer("tag_id", tag_id)
+    for custom_fields_id in custom_fields_ids:
+        indexed_doc.add_integer("custom_fields_id", custom_fields_id)
+    for viewer_id in viewer_ids:
+        indexed_doc.add_integer("viewer_id", viewer_id)
+
+    autocomplete_words = tokenize_for_autocomplete(effective_content)
+
+    # Add also title and note content for autocomplete
+    autocomplete_words.update(tokenize_for_autocomplete(doc.title))
+    autocomplete_words.update(tokenize_for_autocomplete(notes))
+
+    # Make sure to sort the autocomplete word lists.
+    # We assume it's sorted for autocomplete search function.
+    for word in sorted(autocomplete_words):
+        indexed_doc.add_text("autocomplete_word", word)
+    writer.add_document(indexed_doc)
     logger.debug(f"Index updated for document {doc.pk}.")
 
 
-def remove_document(writer: AsyncWriter, doc: Document) -> None:
+def remove_document(writer: tantivy.IndexWriter, doc: Document) -> None:
     remove_document_by_id(writer, doc.pk)
 
 
-def remove_document_by_id(writer: AsyncWriter, doc_id) -> None:
-    writer.delete_by_term("id", doc_id)
+def remove_document_by_id(writer: tantivy.IndexWriter, doc_id) -> None:
+    writer.delete_documents_by_query(
+        tantivy.Query.term_query(get_schema(), "id", doc_id),
+    )
 
 
 def add_or_update_document(document: Document) -> None:
@@ -236,32 +381,128 @@ def add_or_update_document(document: Document) -> None:
         update_document(writer, document)
 
 
+def add_or_update_documents(documents: list[Document], batchsize=0) -> None:
+    if batchsize <= 0:
+        with open_index_writer() as writer:
+            for document in documents:
+                update_document(writer, document)
+    else:
+        for i in range(0, len(documents), batchsize):
+            batch = documents[i : i + batchsize]
+            # do stuff with batch
+            with open_index_writer() as writer:
+                for document in batch:
+                    update_document(writer, document)
+
+
 def remove_document_from_index(document: Document) -> None:
     with open_index_writer() as writer:
         remove_document(writer, document)
 
 
-class MappedDocIdSet(DocIdSet):
+class MappedDocIdSet:
+    def __init__(self, filter_queryset: QuerySet):
+        self.document_ids = set(filter_queryset.values_list("id", flat=True))
+
+    def filter(self, results):
+        # results : list of tantivy.Document
+        return [r for r in results if r.get("id") in self.document_ids]
+
+
+class ResultsPage:
+    """Tantivy result page"""
+
+    results: list
+    pagelen: int
+    pagenum: int
+    total: int
+
+    def __init__(self, results, pagelen, pagenum, total):
+        self.results = results
+        self.pagelen = pagelen
+        self.pagenum = pagenum
+        self.total = total
+
+
+class Hit:
+    def __init__(
+        self,
+        id,
+        score,
+        rank=None,
+        content=None,
+        highlights=None,
+        note_highlights=None,
+    ):
+        self.id: int = id
+        self.score: float = score
+        self.rank: int = rank
+        self.content: str = content
+        self._highlights: str = highlights
+        self._note_highlights: str = note_highlights
+
+    def __getitem__(self, key):
+        if key == "id":
+            return self.id
+        raise KeyError(key)
+
+    def highlights(self, field, *args, **kwargs):
+        text = self._note_highlights if field == "notes" else self._highlights
+        result = text.replace("<b>", '<span class="match">').replace(
+            "</b>",
+            "</span>",
+        )
+        return result
+
+    def __repr__(self):
+        return f"Hit(id={self.id}, score={self.score}, rank={self.rank})"
+
+
+class TantivyResultsPage:
     """
-    A DocIdSet backed by a set of `Document` IDs.
-    Supports efficiently looking up if a whoosh docnum is in the provided `filter_queryset`.
-    """
+    Taken from Whoosh ResultsPage object, for use with Tantivy.
 
-    def __init__(self, filter_queryset: QuerySet, ixreader: IndexReader) -> None:
-        super().__init__()
-        document_ids = filter_queryset.order_by("id").values_list("id", flat=True)
-        max_id = document_ids.last() or 0
-        self.document_ids = BitSet(document_ids, size=max_id)
-        self.ixreader = ixreader
+    This contains all results, but with a pagination system."""
 
-    def __contains__(self, docnum) -> bool:
-        document_id = self.ixreader.stored_fields(docnum)["id"]
-        return document_id in self.document_ids
+    def __init__(self, results: list[Hit], pagenum, pagelen):
+        self.results = results
+        self.total = len(results)
 
-    def __bool__(self) -> Literal[True]:
-        # searcher.search ignores a filter if it's "falsy".
-        # We use this hack so this DocIdSet, when used as a filter, is never ignored.
-        return True
+        if pagenum < 1:
+            raise ValueError("pagenum must be >= 1")
+
+        self.pagecount = math.ceil(self.total / pagelen)
+        self.pagenum = min(self.pagecount, pagenum)
+        offset = (self.pagenum - 1) * pagelen
+        if (offset + pagelen) > self.total:
+            pagelen = self.total - offset
+        self.offset = offset
+        self.pagelen = pagelen
+
+    def __getitem__(self, n):
+        offset = self.offset
+        if isinstance(n, slice):
+            start, stop, step = n.indices(self.pagelen)
+            return self.results.__getitem__(slice(start + offset, stop + offset, step))
+        else:
+            return self.results.__getitem__(n + offset)
+
+    def __iter__(self):
+        return iter(self.results[self.offset : self.offset + self.pagelen])
+
+    def __len__(self):
+        return self.total
+
+    def docnum(self, n):
+        """Returns the document number of the hit at the nth position on this
+        page.
+        """
+        return self.results.docnum(n + self.offset)
+
+    @property
+    def doc_ids(self):
+        """Return the DB ids of the documents in the result page"""
+        return [result.id for result in self.results]
 
 
 class DelayedQuery:
@@ -298,12 +539,18 @@ class DelayedQuery:
         else:
             return sort_fields_map[field], reverse
 
+    def _manual_sort_requested(self):
+        # See https://github.com/paperless-ngx/paperless-ngx/pull/11383
+        # Tantivy implementation was done before this PR. Needs to implement.
+        return False
+
     def __init__(
         self,
-        searcher: Searcher,
+        searcher: tantivy.Searcher,
         query_params,
         page_size,
         filter_queryset: QuerySet,
+        user=None,
     ) -> None:
         self.searcher = searcher
         self.query_params = query_params
@@ -312,7 +559,7 @@ class DelayedQuery:
         self.first_score = None
         self.filter_queryset = filter_queryset
         self.suggested_correction = None
-        self._manual_hits_cache: list | None = None
+        self.user = user
 
     def __len__(self) -> int:
         if self._manual_sort_requested():
@@ -322,53 +569,10 @@ class DelayedQuery:
         page = self[0:1]
         return len(page)
 
-    def _manual_sort_requested(self):
-        ordering = self.query_params.get("ordering", "")
-        return ordering.lstrip("-").startswith("custom_field_")
+    def __getitem__(self, item: slice):
+        import time
 
-    def _manual_hits(self):
-        if self._manual_hits_cache is None:
-            q, mask, suggested_correction = self._get_query()
-            self.suggested_correction = suggested_correction
-
-            results = self.searcher.search(
-                q,
-                mask=mask,
-                filter=MappedDocIdSet(self.filter_queryset, self.searcher.ixreader),
-                limit=None,
-            )
-            results.fragmenter = highlight.ContextFragmenter(surround=50)
-            results.formatter = HtmlFormatter(tagname="span", between=" ... ")
-
-            if not self.first_score and len(results) > 0:
-                self.first_score = results[0].score
-
-            if self.first_score:
-                results.top_n = [
-                    (
-                        (hit[0] / self.first_score) if self.first_score else None,
-                        hit[1],
-                    )
-                    for hit in results.top_n
-                ]
-
-            hits_by_id = {hit["id"]: hit for hit in results}
-            matching_ids = list(hits_by_id.keys())
-
-            ordered_ids = list(
-                self.filter_queryset.filter(id__in=matching_ids).values_list(
-                    "id",
-                    flat=True,
-                ),
-            )
-            ordered_ids = list(dict.fromkeys(ordered_ids))
-
-            self._manual_hits_cache = [
-                hits_by_id[_id] for _id in ordered_ids if _id in hits_by_id
-            ]
-        return self._manual_hits_cache
-
-    def __getitem__(self, item):
+        t0 = time.time()
         if item.start in self.saved_results:
             return self.saved_results[item.start]
 
@@ -382,34 +586,112 @@ class DelayedQuery:
             return page
 
         q, mask, suggested_correction = self._get_query()
+        print(q)
         self.suggested_correction = suggested_correction
-        sortedby, reverse = self._get_query_sortedby()
 
-        page: ResultsPage = self.searcher.search_page(
+        sortedby, reverse = self._get_query_sortedby()
+        order = tantivy.Order.Desc if reverse else tantivy.Order.Asc
+        if isinstance(self, DelayedMoreLikeThisQuery) and sortedby not in [
+            "score",
+            None,
+        ]:
+            # Special case: "more like this" query doesn't support sort and order
+            # So we fetch the IDs of the corresponding items,
+            # then query by theirs IDs to be able to sort them.
+            search_result = self.searcher.search(
+                q,
+                limit=MAX_RESULT_LIMIT,  # TODO set limit for performance?
+            ).hits
+            more_like_this_ids = list()
+            for _, doc_addr in search_result:
+                doc = self.searcher.doc(doc_addr)
+                doc_id = doc["id"][0]
+                more_like_this_ids.append(doc_id)
+            q = tantivy.Query.term_set_query(
+                get_schema(),
+                "id",
+                more_like_this_ids,
+            )
+
+        pagenum = math.floor(item.start / self.page_size) + 1
+        pagelen = self.page_size
+        # offset = (pagenum - 1) * pagelen
+        # print(f"offset: {offset}")
+        t1 = time.time()
+        search_result = self.searcher.search(
             q,
-            mask=mask,
-            filter=MappedDocIdSet(self.filter_queryset, self.searcher.ixreader),
+            # limit=pagelen+1,
+            limit=MAX_RESULT_LIMIT,  # TODO set limit for performance?
+            offset=(pagenum - 1) * pagelen,
+            order_by_field=sortedby,
+            order=order,
+        ).hits
+        # print(f"query and tantivy search took {time.time() - t1:.3f} seconds")
+        results = list()
+        # print(2)
+        # if self.filter_queryset:
+        if self.filter_queryset is not None:
+            # print(3)
+            # print(self.filter_queryset)
+            # print(self.filter_queryset.query)
+            t1 = time.time()
+            allowed_ids = set(self.filter_queryset.values_list("id", flat=True))
+            # print(f"DB query took {time.time() - t1:.3f} seconds")
+            # print(3.1)
+            # print(search_result)
+            content_snippet_generator = tantivy.SnippetGenerator.create(
+                self.searcher,
+                q,
+                get_schema(),
+                "content",
+            )
+            content_snippet_generator.set_max_num_chars(550)
+            note_snippet_generator = tantivy.SnippetGenerator.create(
+                self.searcher,
+                q,
+                get_schema(),
+                "notes",
+            )
+            note_snippet_generator.set_max_num_chars(100)
+            results = list()
+            hit_scores = defaultdict(float)  # doc_id -> max score
+            for score, doc_addr in search_result:
+                doc = self.searcher.doc(doc_addr)
+                doc_id = doc["id"][0]
+                if doc_id in allowed_ids:
+                    # print(3.3)
+                    # results.append({"id": doc["id"][0], "score": score})
+                    hit_scores[doc_id] = max(hit_scores[doc_id], score)
+                    # results.append(Hit(doc["id"][0], score))
+                    # print(3.4)
+
+                    # Generate highlights
+                    content_snippet = content_snippet_generator.snippet_from_doc(doc)
+                    note_snippet = note_snippet_generator.snippet_from_doc(doc)
+
+                    results.append(
+                        Hit(
+                            doc["id"][0],
+                            score,
+                            content=content_snippet.fragment(),
+                            highlights=content_snippet.to_html(),
+                            note_highlights=note_snippet.to_html(),
+                        ),
+                    )
+
+            for idx, hit in enumerate(results, start=1):
+                hit.rank = idx
+
+        else:
+            # TODO
+            raise NotImplementedError
+
+        page = TantivyResultsPage(
+            results=results,
             pagenum=math.floor(item.start / self.page_size) + 1,
             pagelen=self.page_size,
-            sortedby=sortedby,
-            reverse=reverse,
         )
-        page.results.fragmenter = highlight.ContextFragmenter(surround=50)
-        page.results.formatter = HtmlFormatter(tagname="span", between=" ... ")
-
-        if not self.first_score and len(page.results) > 0 and sortedby is None:
-            self.first_score = page.results[0].score
-
-        page.results.top_n = [
-            (
-                (hit[0] / self.first_score) if self.first_score else None,
-                hit[1],
-            )
-            for hit in page.results.top_n
-        ]
-
         self.saved_results[item.start] = page
-
         return page
 
 
@@ -443,40 +725,315 @@ class LocalDateParser(English):
         return d
 
 
+date_parser_plugin = DateParserPlugin(
+    basedate=django_timezone.now(),
+    dateparser=LocalDateParser(),
+)
+
+
+def parse_natural_date(expr: str):
+    """
+    Parse une expression de date naturelle en utilisant le parser anglais de Whoosh.
+    Retourne (start, end).
+    """
+
+    result = date_parser_plugin.dateparser.date_from(expr)
+
+    if not result:
+        return (None, None)
+
+    if isinstance(result, timespan):
+        return result.start, result.end
+    else:
+        raise RuntimeError(f"Unexpected result type: {type(result)}")
+
+
+DATE_FIELDS = ["created", "added", "modified"]
+DATE_QUERY_RE = re.compile(
+    r"""
+    (?P<field>\w+)                    # field ex: created
+    \s*:\s*                           # separator ":"
+    (?P<op>>=|<=|>|<)?\s*             # optional operator
+    (                                 #
+        (?P<bracket_expr>             #   if [expr]
+            \[[^\[\]]*\]
+        )
+        |                             #   or
+        (?P<quoted_expr>              #   expr' or "expr"
+            ['"][^'"]*['"]
+        )
+        |                             #   or
+        (?P<bare_expr>                #   simple expression
+            [^\],'\"]+?
+        )
+    )
+    (?=(?:\s+|,)\w+\s*:|$)            # stop at next field, comma or end
+    """,
+    flags=re.IGNORECASE | re.VERBOSE,
+)
+
+
+def replace_date_expr(match, date_fields=DATE_FIELDS):
+    field = match.group("field").strip()
+    operator = match.group("op") or ""
+    expr = (
+        match.group("bracket_expr")
+        or match.group("quoted_expr")
+        or match.group("bare_expr")
+    )
+    expr = expr.strip("[]'\" ").strip()
+
+    # ignore non-date fields
+    if field not in date_fields:
+        return match.group(0)
+
+    # parse date expression
+    try:
+        start, end = parse_natural_date(expr)
+    except Exception as e:
+        print(f"⚠️ parse_natural_date failed for {expr}: {e}")
+        return match.group(0)
+
+    # si parse_natural_date a renvoyé None
+    if not start and not end:
+        return match.group(0)
+
+    # build Tantivy range
+    if operator in (">", ">="):
+        return f"{field}:[{start.isoformat()} TO *]"
+    elif operator in ("<", "<="):
+        return f"{field}:[* TO {end.isoformat()}]"
+    elif "to" in expr.lower():
+        return f"{field}:[{start.isoformat()} TO {end.isoformat()}]"
+    else:
+        return f"{field}:[{start.isoformat()} TO {end.isoformat()}]"
+
+
+# def preprocess_query_dates(query: str) -> str:
+#     # Convert quotes into brackets first
+#     query = re.sub(
+#         r"(\w+)\s*:\s*(['\"])(.+?)\2",
+#         lambda m: f"{m.group(1)}:[{m.group(3)}]",
+#         query,
+#     )
+
+#     # Replace date expressions
+#     return DATE_QUERY_RE.sub(replace_date_expr, query)
+
+
+def preprocess_query_dates(query: str, date_fields=DATE_FIELDS) -> str:
+    """
+    Only convert quoted expressions to [expr] for *date* fields,
+    then replace date expressions by parsed Tantivy ranges.
+    """
+
+    # Build an alternation of the date field names, e.g. "created|added|modified"
+    # Use re.IGNORECASE so fields are matched case-insensitively.
+    field_alternation = "|".join(map(re.escape, date_fields))
+    quoted_for_date_re = re.compile(
+        rf"(?i)\b(?P<field>{field_alternation})\s*:\s*(['\"])(?P<body>.+?)\2",
+    )
+
+    # Replace only quoted date fields: created:"today" -> created:[today]
+    query = quoted_for_date_re.sub(
+        lambda m: f"{m.group('field')}:[{m.group('body')}]",
+        query,
+    )
+
+    # Now run the main DATE_QUERY_RE substitution which will call replace_date_expr
+    # For re.sub with a function that needs extra args, use a lambda capturing date_fields.
+    return DATE_QUERY_RE.sub(
+        lambda m: replace_date_expr(m, date_fields=date_fields),
+        query,
+    )
+
+
+NQL_TOKENS = ["AND", "OR", "NOT", "TO", "+", "-", "(", ")", '"', "[", "]"]
+
+
+def rewrite_default_and_keywords(query_string: str) -> str:
+    """
+    Separate keywords by AND when natural query language isn't detected.
+    """
+    if not any(
+        [w in query_string for w in NQL_TOKENS],
+    ):
+        # No natural language detected, so separate by AND
+        query_string = re.sub(r"\s+", " AND ", query_string.strip())
+    return query_string
+
+
+# Known keywords in your search syntax
+KEYWORDS = [
+    "content",
+    "bigram_content",
+    "title",
+    "correspondent",
+    "tag",
+    "type",
+    "notes",
+    "custom_fields",
+    "added",
+    "created",
+    "modified",
+]
+
+
+def normalize_query(query: str) -> str:
+    """The front-end can send date filters after a comma.
+    This fixes this by replacing the comma by a "AND" condition with the rest of the query."""
+    # Split by commas
+    parts = [p.strip() for p in query.split(",") if p.strip()]
+
+    normalized_parts = []
+    free_text_parts = []
+
+    for part in parts:
+        # Check if it starts with a known keyword
+        if any(part.startswith(f"{kw}:") for kw in KEYWORDS):
+            # If we already collected free text, wrap it in parentheses
+            if free_text_parts:
+                normalized_parts.append(f"({' '.join(free_text_parts)})")
+                free_text_parts = []
+            normalized_parts.append(part)
+        else:
+            free_text_parts.append(part)
+
+    # Add remaining free text if any
+    if free_text_parts:
+        normalized_parts.append(f"({' '.join(free_text_parts)})")
+
+    # Join everything with AND
+    return " AND ".join(normalized_parts)
+
+
+FIELD_EXPR_RE = re.compile(
+    r"""
+    (?P<field>\w+)
+    \s*:\s*
+    (?P<value>
+        \[[^\[\]]*\]      # plage entre crochets
+        |
+        [^,\s]+           # ou valeur simple
+    )
+    (?:,|(?=\s|$))        # séparée par virgule ou escape/fin
+    """,
+    re.VERBOSE,
+)
+
+
+def extract_query_parts(query: str):
+    """Extract structured filters (field:value) and remaining free text."""
+    filters = []
+    consumed_spans = []
+
+    for match in FIELD_EXPR_RE.finditer(query):
+        field = match.group("field")
+        value = match.group("value")
+        filters.append((field, value))
+        consumed_spans.append(match.span())
+
+    # Remove all matched segments from the original string
+    free_text = query
+    for start, end in reversed(consumed_spans):
+        free_text = free_text[:start] + " " + free_text[end:]
+
+    # Normalize free text
+    text_terms = [
+        t
+        for t in re.findall(r"\w+(?:['’]\w+)?", free_text)  # Noqa RUF001
+        if t and t not in NQL_TOKENS
+    ]
+
+    return {"filters": filters, "text_terms": text_terms}
+
+
 class DelayedFullTextQuery(DelayedQuery):
     def _get_query(self) -> tuple:
         q_str = self.query_params["query"]
+        print(f"raw query: {q_str}")
+
+        q_str = normalize_query(q_str)
+        print(f"normalized query: {q_str}")
         q_str = rewrite_natural_date_keywords(q_str)
-        qp = MultifieldParser(
-            [
-                "content",
-                "title",
-                "correspondent",
-                "tag",
-                "type",
-                "notes",
-                "custom_fields",
-            ],
-            self.searcher.ixreader.schema,
-        )
-        qp.add_plugin(
-            DateParserPlugin(
-                basedate=django_timezone.now(),
-                dateparser=LocalDateParser(),
-            ),
-        )
-        q = qp.parse(q_str)
-        suggested_correction = None
-        try:
-            corrected = self.searcher.correct_query(q, q_str)
-            if corrected.string != q_str:
-                suggested_correction = corrected.string
-        except Exception as e:
-            logger.info(
-                "Error while correcting query %s: %s",
-                f"{q_str!r}",
-                e,
+        print(f"with natural date keywords: {q_str}")
+
+        q_str = rewrite_default_and_keywords(q_str)
+        print(f"with default and keywords: {q_str}")
+        q_str = preprocess_query_dates(q_str)
+        print(f"with dates: {q_str}")
+        text_terms = extract_query_parts(q_str)["text_terms"]
+        print(f"text terms: {text_terms}")
+        if settings.ADVANCED_FUZZY_SEARCH_TRESHOLD and any(
+            [len(t) >= settings.ADVANCED_FUZZY_SEARCH_TRESHOLD for t in text_terms]
+        ):
+            fuzzy_search = True
+        else:
+            fuzzy_search = False
+        # TODO: date parsing plugin like whoosh
+        with open_index() as index:
+            queries = list()
+            q = index.parse_query_lenient(
+                q_str,
+                [
+                    "content",
+                    "bigram_content",
+                    "title",
+                    "correspondent",
+                    "tag",
+                    "type",
+                    "notes",
+                    "custom_fields",
+                    "added",
+                    "created",
+                    "modified",
+                ],
+                field_boosts={"title": 5.0, "content": 0.5},
+                conjunction_by_default=True,
+            )[0]
+            queries.append(q)
+            if fuzzy_search:
+                # An exact match should outweigh a fuzzy one
+                fuzzy_q = index.parse_query_lenient(
+                    # fuzzy field: prefix (prefix must match) bool, distance int, transpose_cost_one (2 letters inverted cost 1 instead of 2): bool
+                    q_str,
+                    [
+                        "content",
+                        "bigram_content",
+                        "title",
+                        "correspondent",
+                        "tag",
+                        "type",
+                        "notes",
+                        "custom_fields",
+                        "added",
+                        "created",
+                        "modified",
+                    ],
+                    field_boosts={"title": 3.0, "content": 0.5},
+                    fuzzy_fields={
+                        "content": (True, 1, True),
+                        "title": (True, 1, True),
+                        "correspondent": (True, 1, True),
+                        "tag": (True, 1, True),
+                        "type": (True, 1, True),
+                        "notes": (True, 1, True),
+                        "custom_fields": (True, 1, True),
+                    },
+                    conjunction_by_default=True,
+                )[0]
+                queries.append(tantivy.Query.boost_query(fuzzy_q, 0.1))
+            q = tantivy.Query.boolean_query(
+                [(tantivy.Occur.Should, q) for q in queries],
             )
+            words = autocomplete(
+                index,
+                q_str,
+                limit=1,
+                user=self.user,
+                fuzzy_search=True,
+            )
+            suggested_correction = words[0] if words and words[0] != q_str else None
 
         return q, None, suggested_correction
 
@@ -484,75 +1041,170 @@ class DelayedFullTextQuery(DelayedQuery):
 class DelayedMoreLikeThisQuery(DelayedQuery):
     def _get_query(self) -> tuple:
         more_like_doc_id = int(self.query_params["more_like_id"])
-        content = Document.objects.get(id=more_like_doc_id).content
 
-        docnum = self.searcher.document_number(id=more_like_doc_id)
-        kts = self.searcher.key_terms_from_text(
-            "content",
-            content,
-            numterms=20,
-            model=classify.Bo1Model,
-            normalize=False,
+        # Fetch the current doc's address
+        current_doc_q = tantivy.Query.term_query(get_schema(), "id", more_like_doc_id)
+
+        doc_address: tantivy.DocAddress = self.searcher.search(
+            current_doc_q,
+            limit=1,
+        ).hits[0][1]
+
+        # Exclude the current doc for "more like this" search results
+        more_like_this_q = tantivy.Query.more_like_this_query(doc_address)
+        q = tantivy.Query.boolean_query(
+            [
+                (tantivy.Occur.Must, more_like_this_q),
+                (tantivy.Occur.MustNot, current_doc_q),
+            ],
         )
-        q = query.Or(
-            [query.Term("content", word, boost=weight) for word, weight in kts],
-        )
-        mask: set = {docnum}
+
+        mask = None  # TODO?
 
         return q, mask, None
 
 
+def _normalize(text: str) -> str:
+    # Decompose characters (NFKD) and remove diacritics
+    return "".join(
+        c for c in unicodedata.normalize("NFKD", text) if not unicodedata.combining(c)
+    ).lower()
+
+
+def prefix_view(sorted_words: list[str], prefix: str):
+    """Return an iterator over words starting with prefix from a given list of sorted words."""
+
+    prefix = _normalize(prefix)
+    start_idx = bisect.bisect_left(sorted_words, prefix)
+
+    # iterate forward lazily, stop when prefix no longer matches
+    def generator():
+        for i in range(start_idx, len(sorted_words)):
+            word = sorted_words[i]
+            if not _normalize(word).startswith(prefix):
+                break
+            yield word
+
+    return generator()
+
+
 def autocomplete(
-    ix: FileIndex,
+    index,
     term: str,
     limit: int = 10,
     user: User | None = None,
-) -> list:
+    *,
+    fuzzy_search=False,
+) -> list[str]:
     """
-    Mimics whoosh.reading.IndexReader.most_distinctive_terms with permissions
-    and without scoring
+    Returns a list of autocomplete suggestions for the given term.
+    Caveat: documents are searched by Tantivy TF-IDF score,
+    but for each document found, all prefixes in this document are added to the list.
+    So only the first prefix is guaranteed to have the highest score.
     """
-    terms = []
+    with open_index() as index:
+        result: list[str] = list()
+        searcher = index.searcher()
+        schema = index.schema
+        perm_q = get_permissions_query(user, schema)
+        normalized_term = _normalize(term)
 
-    with ix.searcher(weighting=TF_IDF()) as s:
-        qp = QueryParser("content", schema=ix.schema)
-        # Don't let searches with a query that happen to match a field override the
-        # content field query instead and return bogus, not text data
-        qp.remove_plugin_class(FieldsPlugin)
-        q = qp.parse(f"{term.lower()}*")
-        user_criterias: list = get_permissions_criterias(user)
-
-        results = s.search(
-            q,
-            terms=True,
-            filter=query.Or(user_criterias) if user_criterias is not None else None,
+        # Find the exact match first
+        exact_subquery = tantivy.Query.term_query(
+            schema,
+            "autocomplete_word",
+            normalized_term,
+        )
+        exact_q = tantivy.Query.boolean_query(
+            [
+                (tantivy.Occur.Must, exact_subquery),
+                (tantivy.Occur.Must, perm_q),
+            ],
         )
 
-        termCounts = Counter()
-        if results.has_matched_terms():
-            for hit in results:
-                for _, match in hit.matched_terms():
-                    termCounts[match] += 1
-            terms = [t for t, _ in termCounts.most_common(limit)]
+        hits = searcher.search(exact_q, limit=1).hits
+        if hits:
+            result.append(term)
 
-        term_encoded: bytes = term.encode("UTF-8")
-        if term_encoded in terms:
-            terms.insert(0, terms.pop(terms.index(term_encoded)))
-
-    return terms
-
-
-def get_permissions_criterias(user: User | None = None) -> list:
-    user_criterias = [query.Term("has_owner", text=False)]
-    if user is not None:
-        if user.is_superuser:  # superusers see all docs
-            user_criterias = []
-        else:
-            user_criterias.append(query.Term("owner_id", user.id))
-            user_criterias.append(
-                query.Term("viewer_id", str(user.id)),
+        # Find prefixed terms until limit is reached
+        try:
+            if fuzzy_search:
+                prefix_subquery = tantivy.Query.fuzzy_term_query(
+                    schema,
+                    "autocomplete_word",
+                    normalized_term,
+                    1,
+                    transposition_cost_one=True,
+                    prefix=True,
+                )
+            else:
+                prefix_subquery = tantivy.Query.regex_query(
+                    schema,
+                    "autocomplete_word",
+                    f"{normalized_term}.*",
+                )
+        except ValueError as e:
+            # Autocomplete doesn't support special terms, e.g. parentheses, +, - etc.
+            logger.debug(f"{e}")
+            return []
+        seen = set()
+        remaining_limit = limit - len(result)
+        while len(result) < limit:
+            seen_q = []
+            for word in seen:
+                seen_q.append(
+                    (
+                        tantivy.Occur.MustNot,
+                        tantivy.Query.term_query(schema, "autocomplete_word", word),
+                    ),
+                )
+            prefix_q = tantivy.Query.boolean_query(
+                [
+                    (tantivy.Occur.MustNot, exact_subquery),
+                    (tantivy.Occur.Must, prefix_subquery),
+                    (tantivy.Occur.Must, perm_q),
+                    *seen_q,
+                ],
             )
-    return user_criterias
+
+            hits = searcher.search(prefix_q, limit=remaining_limit * 5).hits
+            if not hits:
+                return result
+            found_new_word = False
+            for _, addr in hits:
+                doc = searcher.doc(addr)
+                all_words = doc["autocomplete_word"]
+                for word in prefix_view(all_words, normalized_term):
+                    if word in seen:
+                        continue
+                    seen.add(word)
+                    found_new_word = True
+                    result.append(word)
+                    if len(result) >= limit:
+                        return result
+            if not found_new_word:
+                return result
+        return result
+
+
+def get_permissions_query(user: User | None, schema) -> tantivy.Query:
+    # No filter if super user
+    if user and user.is_superuser:
+        return tantivy.Query.all_query()
+
+    # Always return documents with no owner
+    queries = [tantivy.Query.term_query(schema, "has_owner", "false")]
+
+    if user:
+        user_id = str(user.id)
+        queries.extend(
+            [
+                tantivy.Query.term_query(schema, "owner_id", int(user_id)),
+                tantivy.Query.term_query(schema, "viewer_id", int(user_id)),
+            ],
+        )
+
+    return tantivy.Query.boolean_query([(tantivy.Occur.Should, q) for q in queries])
 
 
 def rewrite_natural_date_keywords(query_string: str) -> str:

--- a/src/documents/index.py
+++ b/src/documents/index.py
@@ -1197,36 +1197,21 @@ def autocomplete(
     fuzzy_search=False,
 ) -> list[str]:
     """
-    Returns a list of autocomplete suggestions for the given term.
-    Caveat: documents are searched by Tantivy TF-IDF score,
-    but for each document found, all prefixes in this document are added to the list.
-    So only the first prefix is guaranteed to have the highest score.
+    Returns autocomplete suggestions ranked by document frequency,
+    matching the original Whoosh behavior: terms that appear in more
+    documents are ranked higher. The exact match is always first.
     """
+    from collections import Counter
+
+    if limit <= 0:
+        return []
+
     with open_index() as index:
-        result: list[str] = list()
         searcher = index.searcher()
         schema = index.schema
         perm_q = get_permissions_query(user, schema)
         normalized_term = _normalize(term)
 
-        # Find the exact match first
-        exact_subquery = tantivy.Query.term_query(
-            schema,
-            "autocomplete_word",
-            normalized_term,
-        )
-        exact_q = tantivy.Query.boolean_query(
-            [
-                (tantivy.Occur.Must, exact_subquery),
-                (tantivy.Occur.Must, perm_q),
-            ],
-        )
-
-        hits = searcher.search(exact_q, limit=1).hits
-        if hits:
-            result.append(term)
-
-        # Find prefixed terms until limit is reached
         try:
             if fuzzy_search:
                 prefix_subquery = tantivy.Query.fuzzy_term_query(
@@ -1244,46 +1229,51 @@ def autocomplete(
                     f"{re.escape(normalized_term)}.*",
                 )
         except ValueError as e:
-            # Autocomplete doesn't support special terms, e.g. parentheses, +, - etc.
             logger.debug(f"{e}")
             return []
-        seen = set()
-        remaining_limit = limit - len(result)
-        while len(result) < limit:
-            seen_q = []
-            for word in seen:
-                seen_q.append(
-                    (
-                        tantivy.Occur.MustNot,
-                        tantivy.Query.term_query(schema, "autocomplete_word", word),
-                    ),
-                )
-            prefix_q = tantivy.Query.boolean_query(
-                [
-                    (tantivy.Occur.MustNot, exact_subquery),
-                    (tantivy.Occur.Must, prefix_subquery),
-                    (tantivy.Occur.Must, perm_q),
-                    *seen_q,
-                ],
-            )
 
-            hits = searcher.search(prefix_q, limit=remaining_limit * 5).hits
-            if not hits:
-                return result
-            found_new_word = False
-            for _, addr in hits:
-                doc = searcher.doc(addr)
-                all_words = doc["autocomplete_word"]
-                for word in prefix_view(all_words, normalized_term):
-                    if word in seen:
-                        continue
-                    seen.add(word)
-                    found_new_word = True
-                    result.append(word)
-                    if len(result) >= limit:
-                        return result
-            if not found_new_word:
-                return result
+        prefix_q = tantivy.Query.boolean_query(
+            [
+                (tantivy.Occur.Must, prefix_subquery),
+                (tantivy.Occur.Must, perm_q),
+            ],
+        )
+
+        # Fetch enough documents to get a good frequency count.
+        # Each doc may contain multiple matching words; we count
+        # how many docs each word appears in (= document frequency).
+        doc_limit = limit * 50
+        hits = searcher.search(prefix_q, limit=doc_limit).hits
+
+        # Step 1: count each exact variant (e.g. ouï:1, oui:9)
+        variant_count: Counter[str] = Counter()
+        for _, addr in hits:
+            doc = searcher.doc(addr)
+            all_words = doc["autocomplete_word"]
+            seen_in_doc: set[str] = set()
+            for word in prefix_view(all_words, normalized_term):
+                if word not in seen_in_doc:
+                    seen_in_doc.add(word)
+                    variant_count[word] += 1
+
+        # Step 2: merge variants with same normalization, keep most frequent (eg: oui)
+        best_variant: dict[str, str] = {}
+        merged_count: Counter[str] = Counter()
+        for word, count in variant_count.most_common():
+            key = _normalize(word)
+            if key not in best_variant:
+                # First seen = highest count = best variant
+                best_variant[key] = word
+            merged_count[key] += count
+
+        # Step 3: return best variant for each, ranked by merged count
+        result = [best_variant[key] for key, _ in merged_count.most_common(limit)]
+
+        # Bump the exact match to position 0 if present
+        normalized_match = best_variant.get(normalized_term)
+        if normalized_match and normalized_match in result:
+            result.insert(0, result.pop(result.index(normalized_match)))
+
         return result
 
 

--- a/src/documents/index.py
+++ b/src/documents/index.py
@@ -566,9 +566,38 @@ class DelayedQuery:
             return sort_fields_map[field], reverse
 
     def _manual_sort_requested(self):
-        # See https://github.com/paperless-ngx/paperless-ngx/pull/11383
-        # Tantivy implementation was done before this PR. Needs to implement.
-        return False
+        ordering = self.query_params.get("ordering", "")
+        return ordering.lstrip("-").startswith("custom_field_")
+
+    def _manual_hits(self):
+        if self._manual_hits_cache is not None:
+            return self._manual_hits_cache
+
+        # Fetch all matching IDs directly from Tantivy (permissions + DRF filters)
+        self._build_combined_query()
+        result = self.searcher.search(
+            self._combined_query,
+            limit=MAX_RESULT_LIMIT,
+        )
+        matching_ids = [
+            self.searcher.doc(doc_addr)["id"][0] for _, doc_addr in result.hits
+        ]
+
+        # filter_queryset already has the correct order_by applied
+        # by DocumentsOrderingFilter (annotates custom_field_value + has_field)
+        ordered_ids = list(
+            self.filter_queryset.filter(id__in=matching_ids).values_list(
+                "id",
+                flat=True,
+            ),
+        )
+        ordered_ids = list(dict.fromkeys(ordered_ids))
+
+        self._manual_hits_cache = [
+            Hit(id=doc_id, score=0.0, rank=rank, highlights="", note_highlights="")
+            for rank, doc_id in enumerate(ordered_ids, start=1)
+        ]
+        return self._manual_hits_cache
 
     def __init__(
         self,
@@ -590,6 +619,7 @@ class DelayedQuery:
         self._combined_query = None
         self._sort_field = None
         self._sort_order = None
+        self._manual_hits_cache: list | None = None
 
     def _build_combined_query(self):
         """Build the Tantivy query with permissions and DRF filters baked in. Called once."""
@@ -669,6 +699,8 @@ class DelayedQuery:
 
     def _get_all_ids(self) -> list[int]:
         """Get all matching document IDs (used for "select all" in front-end). Lightweight, without snippets."""
+        if self._manual_sort_requested():
+            return [hit.id for hit in self._manual_hits()]
         self._build_combined_query()
         result = self.searcher.search(
             self._combined_query,
@@ -750,17 +782,10 @@ class DelayedQuery:
 
 
 class ManualResultsPage(list):
+    """A page of manually-sorted Hit objects (backed by Django ordering)."""
+
     def __init__(self, hits):
         super().__init__(hits)
-        self.results = ManualResults(hits)
-
-
-class ManualResults:
-    def __init__(self, hits):
-        self._docnums = [hit.docnum for hit in hits]
-
-    def docs(self):
-        return self._docnums
 
 
 class LocalDateParser(English):

--- a/src/documents/index.py
+++ b/src/documents/index.py
@@ -6,7 +6,9 @@ import math
 import os
 import re
 import threading
+import time as stime
 import unicodedata
+from collections import Counter
 from contextlib import contextmanager
 from datetime import date
 from datetime import datetime
@@ -168,8 +170,6 @@ def recreate_index_dir(path=None):
 
 @contextmanager
 def open_index(*, recreate=False, reload=True, path=None):
-    import time as stime
-
     path = path or _get_index_dir()
     if not Path(path).exists():
         create_index_dir(path)
@@ -243,8 +243,6 @@ class AsyncWriter(threading.Thread):
                 writer = self.index.writer(**self.writerargs)
             except ValueError as e:
                 if self.LOCK_EXC_MSG in str(e):
-                    import time as stime
-
                     stime.sleep(self.delay)
                 else:
                     raise
@@ -602,9 +600,14 @@ class DelayedQuery:
         else:
             return sort_fields_map[field], reverse
 
+    # Text fields can't be sorted by Tantivy's order_by_field (it only works
+    # with numeric/date fast fields). These are routed through Django ORDER BY.
+    _TEXT_SORT_FIELDS = {"title", "correspondent__name", "document_type__name", "owner"}
+
     def _manual_sort_requested(self):
         ordering = self.query_params.get("ordering", "")
-        return ordering.lstrip("-").startswith("custom_field_")
+        field = ordering.lstrip("-")
+        return field.startswith("custom_field_") or field in self._TEXT_SORT_FIELDS
 
     def _manual_hits(self):
         if self._manual_hits_cache is not None:
@@ -692,7 +695,6 @@ class DelayedQuery:
         sortedby, reverse = self._get_query_sortedby()
         self._sort_field = sortedby
         self._sort_order = tantivy.Order.Desc if reverse else tantivy.Order.Asc
-
         # Handle "more like this" special case
         if isinstance(self, DelayedMoreLikeThisQuery) and sortedby not in [
             "score",
@@ -769,7 +771,6 @@ class DelayedQuery:
 
         start = item.start or 0
         page_size = (item.stop - start) if item.stop else self.page_size
-
         result = self.searcher.search(
             q,
             limit=page_size,
@@ -1220,13 +1221,12 @@ def autocomplete(
     user: User | None = None,
     *,
     fuzzy_search=False,
-) -> list[str]:
+) -> list[bytes]:
     """
     Returns autocomplete suggestions ranked by document frequency,
     matching the original Whoosh behavior: terms that appear in more
     documents are ranked higher. The exact match is always first.
     """
-    from collections import Counter
 
     if limit <= 0:
         return []
@@ -1292,14 +1292,19 @@ def autocomplete(
             merged_count[key] += count
 
         # Step 3: return best variant for each, ranked by merged count
-        result = [best_variant[key] for key, _ in merged_count.most_common(limit)]
+        # Tiebreaker: shortest first, then alphabetical (matches Whoosh behavior)
+        ranked = sorted(
+            merged_count.items(),
+            key=lambda kv: (-kv[1], len(kv[0]), kv[0]),
+        )[:limit]
+        result = [best_variant[key] for key, _ in ranked]
 
         # Bump the exact match to position 0 if present
         normalized_match = best_variant.get(normalized_term)
         if normalized_match and normalized_match in result:
             result.insert(0, result.pop(result.index(normalized_match)))
 
-        return result
+        return [word.encode("utf-8") for word in result]
 
 
 def get_permissions_query(user: User | None, schema) -> tantivy.Query:

--- a/src/documents/index.py
+++ b/src/documents/index.py
@@ -281,6 +281,7 @@ def update_document(
     writer: tantivy.IndexWriter,
     doc: Document,
     effective_content: str | None = None,
+    viewer_ids: list[int] | None = None,
 ) -> None:
     if effective_content is None:
         effective_content = doc.content
@@ -303,11 +304,13 @@ def update_document(
             f"{Document.ARCHIVE_SERIAL_NUMBER_MAX:,}.",
         )
         asn = 0
-    users_with_perms = get_users_with_perms(
-        doc,
-        only_with_perms_in=["view_document"],
-    )
-    viewer_ids = [int(u.id) for u in users_with_perms]
+    if viewer_ids is None:
+        # Fallback for single-document indexing (not bulk reindex)
+        users_with_perms = get_users_with_perms(
+            doc,
+            only_with_perms_in=["view_document"],
+        )
+        viewer_ids = [int(u.id) for u in users_with_perms]
 
     writer.delete_documents_by_query(
         tantivy.Query.term_query(get_schema(), "id", doc.pk),

--- a/src/documents/index.py
+++ b/src/documents/index.py
@@ -1015,11 +1015,13 @@ FIELD_EXPR_RE = re.compile(
     (?P<field>\w+)
     \s*:\s*
     (?P<value>
-        \[[^\[\]]*\]      # plage entre crochets
+        \[[^\[\]]*\]      # [...]
         |
-        [^,\s]+           # ou valeur simple
+        \([^)]*\)         # (...)
+        |
+        [^,\s]+           # simple value
     )
-    (?:,|(?=[\s)]|$))     # séparée par virgule, escape, parenthèse fermante ou fin
+    (?:,|(?=[\s)]|$))     # separated by comma, escape, closing parentheses or end
     """,
     re.VERBOSE,
 )

--- a/src/documents/index.py
+++ b/src/documents/index.py
@@ -96,7 +96,6 @@ def get_schema():
     sb.add_text_field(
         "title",
         stored=True,
-        index_option="basic",
         tokenizer_name="simple_analyzer",
     )
     sb.add_text_field("title_sort", fast=True, index_option="basic")
@@ -1073,28 +1072,41 @@ def extract_query_parts(query: str):
     return {"filters": filters, "text_terms": text_terms}
 
 
+def preprocess_query(query: str) -> tuple[str, list[str]]:
+    """
+    Preprocess a raw user query string before passing it to Tantivy's query parser.
+
+    Applies all rewrite steps in order:
+    1. rewrite_natural_date_keywords: today/yesterday/this month… → UTC ISO ranges
+    2. normalize_query: comma-separated parts → AND joins
+    3. preprocess_query_dates: remaining date expressions (Whoosh parser) → ISO ranges
+    4. extract_query_parts: extract free text terms (for fuzzy search decision)
+
+    Returns:
+        (rewritten_query, text_terms)
+    """
+    logger.debug(f"raw query: {query}")
+    query = rewrite_natural_date_keywords(query)
+    logger.debug(f"after natural date keywords: {query}")
+    query = normalize_query(query)
+    logger.debug(f"after normalize: {query}")
+    query = preprocess_query_dates(query)
+    logger.debug(f"after date preprocessing: {query}")
+    text_terms = extract_query_parts(query)["text_terms"]
+    logger.debug(f"text terms: {text_terms}")
+    return query, text_terms
+
+
 class DelayedFullTextQuery(DelayedQuery):
     def _get_query(self) -> tuple:
-        q_str = self.query_params["query"]
-        logger.debug(f"raw query: {q_str}")
-        q_str = rewrite_natural_date_keywords(q_str)
-        logger.debug(f"with natural date keywords: {q_str}")
-        q_str = normalize_query(q_str)
-        logger.debug(f"normalized query: {q_str}")
+        q_str, text_terms = preprocess_query(self.query_params["query"])
 
-        q_str = rewrite_default_and_keywords(q_str)
-        logger.debug(f"with default and keywords: {q_str}")
-        q_str = preprocess_query_dates(q_str)
-        logger.debug(f"with dates: {q_str}")
-        text_terms = extract_query_parts(q_str)["text_terms"]
-        logger.debug(f"text terms: {text_terms}")
         if settings.ADVANCED_FUZZY_SEARCH_TRESHOLD and any(
             [len(t) >= settings.ADVANCED_FUZZY_SEARCH_TRESHOLD for t in text_terms],
         ):
             fuzzy_search = True
         else:
             fuzzy_search = False
-        # TODO: date parsing plugin like whoosh
 
         with open_index() as index:
             queries = list()

--- a/src/documents/index.py
+++ b/src/documents/index.py
@@ -592,22 +592,35 @@ class DelayedQuery:
         self._sort_order = None
 
     def _build_combined_query(self):
-        """Build the Tantivy query with permissions baked in. Called once."""
+        """Build the Tantivy query with permissions and DRF filters baked in. Called once."""
         if self._combined_query is not None:
             return
 
         q, mask, suggested_correction = self._get_query()
         self.suggested_correction = suggested_correction
 
-        # Combine search query with permissions query
         schema = get_schema()
         perm_q = get_permissions_query(self.user, schema)
-        self._combined_query = tantivy.Query.boolean_query(
-            [
-                (tantivy.Occur.Must, q),
-                (tantivy.Occur.Must, perm_q),
-            ],
-        )
+
+        clauses = [
+            (tantivy.Occur.Must, q),
+            (tantivy.Occur.Must, perm_q),
+        ]
+
+        # Apply DRF filters (tags, correspondent, type, etc.) via filter_queryset
+        if self.filter_queryset is not None:
+            base_count = Document.objects.count()
+            filtered_ids = list(self.filter_queryset.values_list("id", flat=True))
+            if len(filtered_ids) < base_count:
+                # Extra filters are active — restrict Tantivy results to these IDs
+                filter_q = tantivy.Query.term_set_query(
+                    schema,
+                    "id",
+                    filtered_ids,
+                )
+                clauses.append((tantivy.Occur.Must, filter_q))
+
+        self._combined_query = tantivy.Query.boolean_query(clauses)
 
         sortedby, reverse = self._get_query_sortedby()
         self._sort_field = sortedby

--- a/src/documents/index.py
+++ b/src/documents/index.py
@@ -776,6 +776,17 @@ class DelayedQuery:
                 ),
             )
 
+        # Normalize scores relative to the global best match (only for relevance sort)
+        if self._sort_field is None and hits:
+            if not self.first_score:
+                # Fetch the top-1 result's score (offset=0) regardless of current page
+                top_result = self.searcher.search(q, limit=1)
+                if top_result.hits:
+                    self.first_score = top_result.hits[0][0]
+            if self.first_score:
+                for hit in hits:
+                    hit.score = hit.score / self.first_score
+
         page = SimplePage(results=hits, total=result.count)
         self.saved_results[start] = page
         return page

--- a/src/documents/index.py
+++ b/src/documents/index.py
@@ -1090,7 +1090,8 @@ def preprocess_query(query: str) -> tuple[str, list[str]]:
 
 class DelayedFullTextQuery(DelayedQuery):
     def _get_query(self) -> tuple:
-        q_str = preprocess_query(self.query_params["query"])
+        raw_query = self.query_params["query"]
+        q_str = preprocess_query(raw_query)
 
         if settings.ADVANCED_FUZZY_SEARCH_TRESHOLD and any(
             [
@@ -1156,12 +1157,15 @@ class DelayedFullTextQuery(DelayedQuery):
             )
             words = autocomplete(
                 index,
-                q_str,
+                raw_query,
                 limit=1,
                 user=self.user,
                 fuzzy_search=True,
             )
-            suggested_correction = words[0] if words and words[0] != q_str else None
+            top_word = words[0].decode("utf-8") if words else None
+            suggested_correction = (
+                top_word if top_word and top_word != raw_query else None
+            )
 
         return q, suggested_correction
 

--- a/src/documents/index.py
+++ b/src/documents/index.py
@@ -164,7 +164,7 @@ def create_index_dir(path=None):
 def recreate_index_dir(path=None):
     """Clear the Tantivy index by deleting and recreating its directory."""
     path = path or _get_index_dir()
-    rmtree(path)
+    rmtree(path, ignore_errors=True)
     create_index_dir(path)
 
 

--- a/src/documents/index.py
+++ b/src/documents/index.py
@@ -43,7 +43,7 @@ index_dir = f"{settings.INDEX_DIR}_tantivy"
 CJK_RE = re.compile(r"[\u4e00-\u9fff\u3040-\u30ff\uac00-\ud7af]+")
 WORD_RE = re.compile(r"\w+", flags=re.IGNORECASE)
 
-MAX_RESULT_LIMIT = 1001
+MAX_RESULT_LIMIT = 10001
 
 
 def extract_bigram_content(text: str) -> str:
@@ -916,7 +916,7 @@ FIELD_EXPR_RE = re.compile(
         |
         [^,\s]+           # ou valeur simple
     )
-    (?:,|(?=\s|$))        # séparée par virgule ou escape/fin
+    (?:,|(?=[\s)]|$))     # séparée par virgule, escape, parenthèse fermante ou fin
     """,
     re.VERBOSE,
 )
@@ -952,11 +952,10 @@ class DelayedFullTextQuery(DelayedQuery):
     def _get_query(self) -> tuple:
         q_str = self.query_params["query"]
         print(f"raw query: {q_str}")
-
-        q_str = normalize_query(q_str)
-        print(f"normalized query: {q_str}")
         q_str = rewrite_natural_date_keywords(q_str)
         print(f"with natural date keywords: {q_str}")
+        q_str = normalize_query(q_str)
+        print(f"normalized query: {q_str}")
 
         q_str = rewrite_default_and_keywords(q_str)
         print(f"with default and keywords: {q_str}")
@@ -1285,9 +1284,9 @@ def rewrite_natural_date_keywords(query_string: str) -> str:
                 start = datetime(local_now.year - 1, 1, 1, 0, 0, 0, tzinfo=tz)
                 end = datetime(local_now.year - 1, 12, 31, 23, 59, 59, tzinfo=tz)
 
-        # Convert to UTC and format
-        start_str = start.astimezone(timezone.utc).strftime("%Y%m%d%H%M%S")
-        end_str = end.astimezone(timezone.utc).strftime("%Y%m%d%H%M%S")
+        # Convert to UTC and format as RFC 3339 for Tantivy date fields
+        start_str = start.astimezone(timezone.utc).isoformat()
+        end_str = end.astimezone(timezone.utc).isoformat()
         return f"{field}:[{start_str} TO {end_str}]"
 
     return re.sub(pattern, repl, query_string, flags=re.IGNORECASE)

--- a/src/documents/index.py
+++ b/src/documents/index.py
@@ -626,7 +626,7 @@ class DelayedQuery:
         if self._combined_query is not None:
             return
 
-        q, mask, suggested_correction = self._get_query()
+        q, suggested_correction = self._get_query()
         self.suggested_correction = suggested_correction
 
         schema = get_schema()
@@ -1113,7 +1113,7 @@ class DelayedFullTextQuery(DelayedQuery):
             )
             suggested_correction = words[0] if words and words[0] != q_str else None
 
-        return q, None, suggested_correction
+        return q, suggested_correction
 
 
 class DelayedMoreLikeThisQuery(DelayedQuery):
@@ -1137,9 +1137,7 @@ class DelayedMoreLikeThisQuery(DelayedQuery):
             ],
         )
 
-        mask = None  # TODO?
-
-        return q, mask, None
+        return q, None
 
 
 def _normalize(text: str) -> str:

--- a/src/documents/index.py
+++ b/src/documents/index.py
@@ -7,7 +7,6 @@ import os
 import re
 import threading
 import unicodedata
-from collections import defaultdict
 from contextlib import contextmanager
 from datetime import datetime
 from datetime import time
@@ -505,6 +504,27 @@ class TantivyResultsPage:
         return [result.id for result in self.results]
 
 
+class SimplePage:
+    """A pre-sliced page of results. No internal re-pagination."""
+
+    def __init__(self, results: list[Hit], total: int):
+        self.results = results
+        self.total = total
+
+    def __getitem__(self, n):
+        return self.results[n]
+
+    def __iter__(self):
+        return iter(self.results)
+
+    def __len__(self):
+        return self.total
+
+    @property
+    def doc_ids(self):
+        return [hit.id for hit in self.results]
+
+
 class DelayedQuery:
     def _get_query(self):
         raise NotImplementedError  # pragma: no cover
@@ -560,19 +580,90 @@ class DelayedQuery:
         self.filter_queryset = filter_queryset
         self.suggested_correction = None
         self.user = user
+        self._count: int | None = None
+        self._combined_query = None
+        self._sort_field = None
+        self._sort_order = None
+
+    def _build_combined_query(self):
+        """Build the Tantivy query with permissions baked in. Called once."""
+        if self._combined_query is not None:
+            return
+
+        q, mask, suggested_correction = self._get_query()
+        self.suggested_correction = suggested_correction
+
+        # Combine search query with permissions query
+        schema = get_schema()
+        perm_q = get_permissions_query(self.user, schema)
+        self._combined_query = tantivy.Query.boolean_query(
+            [
+                (tantivy.Occur.Must, q),
+                (tantivy.Occur.Must, perm_q),
+            ],
+        )
+
+        sortedby, reverse = self._get_query_sortedby()
+        self._sort_field = sortedby
+        self._sort_order = tantivy.Order.Desc if reverse else tantivy.Order.Asc
+
+        # Handle "more like this" special case
+        if isinstance(self, DelayedMoreLikeThisQuery) and sortedby not in [
+            "score",
+            None,
+        ]:
+            search_result = self.searcher.search(
+                self._combined_query,
+                limit=MAX_RESULT_LIMIT,
+            ).hits
+            more_like_this_ids = [
+                self.searcher.doc(doc_addr)["id"][0] for _, doc_addr in search_result
+            ]
+            self._combined_query = tantivy.Query.boolean_query(
+                [
+                    (
+                        tantivy.Occur.Must,
+                        tantivy.Query.term_set_query(
+                            schema,
+                            "id",
+                            more_like_this_ids,
+                        ),
+                    ),
+                    (tantivy.Occur.Must, perm_q),
+                ],
+            )
 
     def __len__(self) -> int:
         if self._manual_sort_requested():
             manual_hits = self._manual_hits()
             return len(manual_hits)
 
-        page = self[0:1]
-        return len(page)
+        if self._count is None:
+            self._build_combined_query()
+            # In tantivy, no need to fetch all results to count them, one is enough
+            result = self.searcher.search(
+                self._combined_query,
+                limit=1,
+            )
+            self._count = result.count
+        return self._count
+
+    def _get_all_ids(self) -> list[int]:
+        """Get all matching document IDs (used for "select all" in front-end). Lightweight, without snippets."""
+        self._build_combined_query()
+        result = self.searcher.search(
+            self._combined_query,
+            limit=MAX_RESULT_LIMIT,
+            order_by_field=self._sort_field,
+            order=self._sort_order,
+        )
+        ids = []
+        for _, doc_addr in result.hits:
+            doc = self.searcher.doc(doc_addr)
+            ids.append(doc["id"][0])
+        return ids
 
     def __getitem__(self, item: slice):
-        import time
-
-        t0 = time.time()
         if item.start in self.saved_results:
             return self.saved_results[item.start]
 
@@ -585,113 +676,57 @@ class DelayedQuery:
             self.saved_results[start] = page
             return page
 
-        q, mask, suggested_correction = self._get_query()
-        print(q)
-        self.suggested_correction = suggested_correction
+        self._build_combined_query()
+        q = self._combined_query
 
-        sortedby, reverse = self._get_query_sortedby()
-        order = tantivy.Order.Desc if reverse else tantivy.Order.Asc
-        if isinstance(self, DelayedMoreLikeThisQuery) and sortedby not in [
-            "score",
-            None,
-        ]:
-            # Special case: "more like this" query doesn't support sort and order
-            # So we fetch the IDs of the corresponding items,
-            # then query by theirs IDs to be able to sort them.
-            search_result = self.searcher.search(
-                q,
-                limit=MAX_RESULT_LIMIT,  # TODO set limit for performance?
-            ).hits
-            more_like_this_ids = list()
-            for _, doc_addr in search_result:
-                doc = self.searcher.doc(doc_addr)
-                doc_id = doc["id"][0]
-                more_like_this_ids.append(doc_id)
-            q = tantivy.Query.term_set_query(
-                get_schema(),
-                "id",
-                more_like_this_ids,
-            )
+        start = item.start or 0
+        page_size = (item.stop - start) if item.stop else self.page_size
 
-        pagenum = math.floor(item.start / self.page_size) + 1
-        pagelen = self.page_size
-        # offset = (pagenum - 1) * pagelen
-        # print(f"offset: {offset}")
-        t1 = time.time()
-        search_result = self.searcher.search(
+        result = self.searcher.search(
             q,
-            # limit=pagelen+1,
-            limit=MAX_RESULT_LIMIT,  # TODO set limit for performance?
-            offset=(pagenum - 1) * pagelen,
-            order_by_field=sortedby,
-            order=order,
-        ).hits
-        # print(f"query and tantivy search took {time.time() - t1:.3f} seconds")
-        results = list()
-        # print(2)
-        # if self.filter_queryset:
-        if self.filter_queryset is not None:
-            # print(3)
-            # print(self.filter_queryset)
-            # print(self.filter_queryset.query)
-            t1 = time.time()
-            allowed_ids = set(self.filter_queryset.values_list("id", flat=True))
-            # print(f"DB query took {time.time() - t1:.3f} seconds")
-            # print(3.1)
-            # print(search_result)
-            content_snippet_generator = tantivy.SnippetGenerator.create(
-                self.searcher,
-                q,
-                get_schema(),
-                "content",
-            )
-            content_snippet_generator.set_max_num_chars(550)
-            note_snippet_generator = tantivy.SnippetGenerator.create(
-                self.searcher,
-                q,
-                get_schema(),
-                "notes",
-            )
-            note_snippet_generator.set_max_num_chars(100)
-            results = list()
-            hit_scores = defaultdict(float)  # doc_id -> max score
-            for score, doc_addr in search_result:
-                doc = self.searcher.doc(doc_addr)
-                doc_id = doc["id"][0]
-                if doc_id in allowed_ids:
-                    # print(3.3)
-                    # results.append({"id": doc["id"][0], "score": score})
-                    hit_scores[doc_id] = max(hit_scores[doc_id], score)
-                    # results.append(Hit(doc["id"][0], score))
-                    # print(3.4)
-
-                    # Generate highlights
-                    content_snippet = content_snippet_generator.snippet_from_doc(doc)
-                    note_snippet = note_snippet_generator.snippet_from_doc(doc)
-
-                    results.append(
-                        Hit(
-                            doc["id"][0],
-                            score,
-                            content=content_snippet.fragment(),
-                            highlights=content_snippet.to_html(),
-                            note_highlights=note_snippet.to_html(),
-                        ),
-                    )
-
-            for idx, hit in enumerate(results, start=1):
-                hit.rank = idx
-
-        else:
-            # TODO
-            raise NotImplementedError
-
-        page = TantivyResultsPage(
-            results=results,
-            pagenum=math.floor(item.start / self.page_size) + 1,
-            pagelen=self.page_size,
+            limit=page_size,
+            offset=start,
+            order_by_field=self._sort_field,
+            order=self._sort_order,
         )
-        self.saved_results[item.start] = page
+
+        if self._count is None:
+            self._count = result.count
+
+        # Generate snippets only for this page
+        content_snippet_generator = tantivy.SnippetGenerator.create(
+            self.searcher,
+            q,
+            get_schema(),
+            "content",
+        )
+        content_snippet_generator.set_max_num_chars(550)
+        note_snippet_generator = tantivy.SnippetGenerator.create(
+            self.searcher,
+            q,
+            get_schema(),
+            "notes",
+        )
+        note_snippet_generator.set_max_num_chars(100)
+
+        hits = []
+        for rank, (score, doc_addr) in enumerate(result.hits, start=start + 1):
+            doc = self.searcher.doc(doc_addr)
+            content_snippet = content_snippet_generator.snippet_from_doc(doc)
+            note_snippet = note_snippet_generator.snippet_from_doc(doc)
+            hits.append(
+                Hit(
+                    doc["id"][0],
+                    score,
+                    rank=rank,
+                    content=content_snippet.fragment(),
+                    highlights=content_snippet.to_html(),
+                    note_highlights=note_snippet.to_html(),
+                ),
+            )
+
+        page = SimplePage(results=hits, total=result.count)
+        self.saved_results[start] = page
         return page
 
 
@@ -964,7 +999,7 @@ class DelayedFullTextQuery(DelayedQuery):
         text_terms = extract_query_parts(q_str)["text_terms"]
         print(f"text terms: {text_terms}")
         if settings.ADVANCED_FUZZY_SEARCH_TRESHOLD and any(
-            [len(t) >= settings.ADVANCED_FUZZY_SEARCH_TRESHOLD for t in text_terms]
+            [len(t) >= settings.ADVANCED_FUZZY_SEARCH_TRESHOLD for t in text_terms],
         ):
             fuzzy_search = True
         else:

--- a/src/documents/index.py
+++ b/src/documents/index.py
@@ -360,7 +360,7 @@ def update_document(
         has_owner=bool(doc.owner and doc.owner.id is not None),
         checksum=doc.checksum or "",
         page_count=doc.page_count or 0,
-        original_filename=doc.original_filename,
+        original_filename=doc.original_filename or "",
         is_shared=len(viewer_ids) > 0,
     )
     for tag_id in tags_ids:

--- a/src/documents/index.py
+++ b/src/documents/index.py
@@ -8,6 +8,7 @@ import re
 import threading
 import unicodedata
 from contextlib import contextmanager
+from datetime import date
 from datetime import datetime
 from datetime import time
 from datetime import timedelta
@@ -1327,7 +1328,8 @@ def rewrite_natural_date_keywords(query_string: str) -> str:
 
             case "this month":
                 start = datetime(local_now.year, local_now.month, 1, 0, 0, 0, tzinfo=tz)
-                end = start + relativedelta(months=1) - timedelta(seconds=1)
+                last_day = (start + relativedelta(months=1) - timedelta(days=1)).date()
+                end = datetime.combine(last_day, time.max, tzinfo=tz)
 
             case "previous month":
                 this_month_start = datetime(
@@ -1340,11 +1342,16 @@ def rewrite_natural_date_keywords(query_string: str) -> str:
                     tzinfo=tz,
                 )
                 start = this_month_start - relativedelta(months=1)
-                end = this_month_start - timedelta(seconds=1)
+                last_day = (this_month_start - timedelta(days=1)).date()
+                end = datetime.combine(last_day, time.max, tzinfo=tz)
 
             case "this year":
                 start = datetime(local_now.year, 1, 1, 0, 0, 0, tzinfo=tz)
-                end = datetime(local_now.year, 12, 31, 23, 59, 59, tzinfo=tz)
+                end = datetime.combine(
+                    date(local_now.year, 12, 31),
+                    time.max,
+                    tzinfo=tz,
+                )
 
             case "previous week":
                 days_since_monday = local_now.weekday()
@@ -1354,7 +1361,8 @@ def rewrite_natural_date_keywords(query_string: str) -> str:
                     tzinfo=tz,
                 )
                 start = this_week_start - timedelta(days=7)
-                end = this_week_start - timedelta(seconds=1)
+                last_day = (this_week_start - timedelta(days=1)).date()
+                end = datetime.combine(last_day, time.max, tzinfo=tz)
 
             case "previous quarter":
                 current_quarter = (local_now.month - 1) // 3 + 1
@@ -1369,11 +1377,16 @@ def rewrite_natural_date_keywords(query_string: str) -> str:
                     tzinfo=tz,
                 )
                 start = this_quarter_start - relativedelta(months=3)
-                end = this_quarter_start - timedelta(seconds=1)
+                last_day = (this_quarter_start - timedelta(days=1)).date()
+                end = datetime.combine(last_day, time.max, tzinfo=tz)
 
             case "previous year":
                 start = datetime(local_now.year - 1, 1, 1, 0, 0, 0, tzinfo=tz)
-                end = datetime(local_now.year - 1, 12, 31, 23, 59, 59, tzinfo=tz)
+                end = datetime.combine(
+                    date(local_now.year - 1, 12, 31),
+                    time.max,
+                    tzinfo=tz,
+                )
 
         # Convert to UTC and format as RFC 3339 for Tantivy date fields
         start_str = start.astimezone(timezone.utc).isoformat()

--- a/src/documents/index.py
+++ b/src/documents/index.py
@@ -152,28 +152,49 @@ def get_schema():
     return sb.build()
 
 
-def recreate_index_dir(path=index_dir):
-    if Path(path).exists():
-        rmtree(path)
+def create_index_dir(path=index_dir):
+    """Create the Tantivy index directory if it doesn't exist."""
     Path(path).mkdir(parents=True, exist_ok=True)
 
 
+def recreate_index_dir(path=index_dir):
+    """Clear the Tantivy index by deleting and recreating its directory."""
+    rmtree(path)
+    create_index_dir(path)
+
+
 @contextmanager
-def open_index(*, recreate=False, reload=True):
-    path = index_dir
-    if recreate or not Path(path).exists():
+def open_index(*, recreate=False, reload=True, path=index_dir):
+    import time as stime
+
+    if not Path(path).exists():
+        create_index_dir(path)
+    elif recreate:
         recreate_index_dir(path)
-    try:
-        index = tantivy.Index(schema=get_schema(), path=path)
-        index.register_tokenizer("bigram_analyzer", bigram_analyzer)
-        index.register_tokenizer("simple_analyzer", simple_analyzer)
-    except ValueError as e:
-        # Schema has changed
-        logger.warning(f"Recreating index due to error: {e}")
+    nb_attempts = 3
+    for attempt in range(nb_attempts):
+        try:
+            index = tantivy.Index(schema=get_schema(), path=path)
+            index.register_tokenizer("bigram_analyzer", bigram_analyzer)
+            index.register_tokenizer("simple_analyzer", simple_analyzer)
+            break
+        except ValueError as e:
+            logger.warning(f"Recreating index due to schema error: {e}")
+            recreate_index_dir(path)
+            index = tantivy.Index(schema=get_schema(), path=path)
+            break
+        except Exception as e:
+            logger.warning(
+                f"Error opening index (attempt {attempt + 1}/{nb_attempts}): {e}",
+            )
+            stime.sleep(0.1)
+    else:
+        logger.error(f"Failed to open index after {nb_attempts} attempts. Recreating.")
         recreate_index_dir(path)
         index = tantivy.Index(schema=get_schema(), path=path)
+
     if reload:
-        index.reload()  # Ensure we have the latest commit?
+        index.reload()
     yield index
 
 

--- a/src/documents/index.py
+++ b/src/documents/index.py
@@ -91,7 +91,14 @@ def get_schema():
     sb = tantivy.SchemaBuilder()
     # TODO are all the has_ really needed?
     sb.add_integer_field("id", stored=True, indexed=True)
-    sb.add_text_field("title", stored=True, fast=True, index_option="basic")
+    # Custom analyzer cannot be used for sorting, so two fields are needed if we want to be diacritic insensitive
+    sb.add_text_field(
+        "title",
+        stored=True,
+        index_option="basic",
+        tokenizer_name="simple_analyzer",
+    )
+    sb.add_text_field("title_sort", fast=True, index_option="basic")
     sb.add_text_field(
         "autocomplete_word",
         stored=True,
@@ -105,13 +112,15 @@ def get_schema():
         index_option="freq",
     )  # used for languages such as CJK
     sb.add_integer_field("asn", stored=True, fast=True)
-    sb.add_text_field("correspondent", stored=True, fast=True, tokenizer_name="default")
+    sb.add_text_field("correspondent", stored=True, tokenizer_name="simple_analyzer")
+    sb.add_text_field("correspondent_sort", fast=True)
     sb.add_integer_field("correspondent_id", stored=True)
     sb.add_boolean_field("has_correspondent", stored=True)
     sb.add_text_field("tag", stored=True, tokenizer_name="simple_analyzer")
     sb.add_integer_field("tag_id", stored=True)
     sb.add_boolean_field("has_tag", stored=True)
-    sb.add_text_field("type", stored=True, fast=True, tokenizer_name="default")
+    sb.add_text_field("type", stored=True, tokenizer_name="simple_analyzer")
+    sb.add_text_field("type_sort", fast=True)
     sb.add_integer_field("type_id", stored=True)
     sb.add_boolean_field("has_type", stored=True)
     sb.add_date_field(
@@ -321,14 +330,17 @@ def update_document(
     indexed_doc = tantivy.Document(
         id=doc.pk,
         title=doc.title or "",
+        title_sort=doc.title or "",
         content=effective_content,
         bigram_content=extract_bigram_content(effective_content),
         correspondent=doc.correspondent.name if doc.correspondent else "",
+        correspondent_sort=doc.correspondent.name if doc.correspondent else "",
         correspondent_id=doc.correspondent.id if doc.correspondent else 0,
         has_correspondent=doc.correspondent is not None,
         tag=tags,
         has_tag=len(tags) > 0,
         type=doc.document_type.name if doc.document_type else "",
+        type_sort=doc.document_type.name if doc.document_type else "",
         type_id=doc.document_type.id if doc.document_type else 0,
         has_type=doc.document_type is not None,
         created=datetime_to_tantivy(datetime.combine(doc.created, time.min)),
@@ -546,9 +558,9 @@ class DelayedQuery:
             "created": "created",
             "modified": "modified",
             "added": "added",
-            "title": "title",
-            "correspondent__name": "correspondent",
-            "document_type__name": "type",
+            "title": "title_sort",
+            "correspondent__name": "correspondent_sort",
+            "document_type__name": "type_sort",
             "archive_serial_number": "asn",
             "num_notes": "num_notes",
             "owner": "owner",

--- a/src/documents/index.py
+++ b/src/documents/index.py
@@ -161,6 +161,14 @@ def create_index_dir(path=None):
     Path(path or _get_index_dir()).mkdir(parents=True, exist_ok=True)
 
 
+def get_index_last_modified() -> float | None:
+    """Return the mtime of the Tantivy meta.json, or None if it doesn't exist."""
+    meta_path = Path(_get_index_dir()) / "meta.json"
+    if meta_path.exists():
+        return meta_path.stat().st_mtime
+    return None
+
+
 def recreate_index_dir(path=None):
     """Clear the Tantivy index by deleting and recreating its directory."""
     path = path or _get_index_dir()

--- a/src/documents/index.py
+++ b/src/documents/index.py
@@ -244,8 +244,8 @@ class AsyncWriter(threading.Thread):
 
 
 @contextmanager
-def open_index_writer(*, reload=True, **kwargs):
-    with open_index(reload=reload) as index:
+def open_index_writer(*, recreate=False, reload=True, **kwargs):
+    with open_index(recreate=recreate, reload=reload) as index:
         writer = AsyncWriter(index, num_threads=os.cpu_count() or 0)
         try:
             yield writer
@@ -678,8 +678,8 @@ class DelayedQuery:
         )
         ids = []
         for _, doc_addr in result.hits:
-            doc = self.searcher.doc(doc_addr)
-            ids.append(doc["id"][0])
+            doc_id = self.searcher.doc(doc_addr)["id"][0]
+            ids.append(doc_id)
         return ids
 
     def __getitem__(self, item: slice):

--- a/src/documents/index.py
+++ b/src/documents/index.py
@@ -916,7 +916,7 @@ def replace_date_expr(match, date_fields=DATE_FIELDS):
     try:
         start, end = parse_natural_date(expr)
     except Exception as e:
-        print(f"⚠️ parse_natural_date failed for {expr}: {e}")
+        logger.debug(f"parse_natural_date({expr}) failed: {e}")
         return match.group(0)
 
     # si parse_natural_date a renvoyé None
@@ -1078,18 +1078,18 @@ def extract_query_parts(query: str):
 class DelayedFullTextQuery(DelayedQuery):
     def _get_query(self) -> tuple:
         q_str = self.query_params["query"]
-        print(f"raw query: {q_str}")
+        logger.debug(f"raw query: {q_str}")
         q_str = rewrite_natural_date_keywords(q_str)
-        print(f"with natural date keywords: {q_str}")
+        logger.debug(f"with natural date keywords: {q_str}")
         q_str = normalize_query(q_str)
-        print(f"normalized query: {q_str}")
+        logger.debug(f"normalized query: {q_str}")
 
         q_str = rewrite_default_and_keywords(q_str)
-        print(f"with default and keywords: {q_str}")
+        logger.debug(f"with default and keywords: {q_str}")
         q_str = preprocess_query_dates(q_str)
-        print(f"with dates: {q_str}")
+        logger.debug(f"with dates: {q_str}")
         text_terms = extract_query_parts(q_str)["text_terms"]
-        print(f"text terms: {text_terms}")
+        logger.debug(f"text terms: {text_terms}")
         if settings.ADVANCED_FUZZY_SEARCH_TRESHOLD and any(
             [len(t) >= settings.ADVANCED_FUZZY_SEARCH_TRESHOLD for t in text_terms],
         ):
@@ -1305,7 +1305,7 @@ def get_permissions_query(user: User | None, schema) -> tantivy.Query:
         return tantivy.Query.all_query()
 
     # Always return documents with no owner
-    queries = [tantivy.Query.term_query(schema, "has_owner", False)]
+    queries = [tantivy.Query.term_query(schema, "has_owner", field_value=False)]
 
     if user:
         user_id = str(user.id)

--- a/src/documents/index.py
+++ b/src/documents/index.py
@@ -326,6 +326,7 @@ def update_document(
         correspondent=doc.correspondent.name if doc.correspondent else "",
         correspondent_id=doc.correspondent.id if doc.correspondent else 0,
         has_correspondent=doc.correspondent is not None,
+        tag=tags,
         has_tag=len(tags) > 0,
         type=doc.document_type.name if doc.document_type else "",
         type_id=doc.document_type.id if doc.document_type else 0,

--- a/src/documents/management/commands/document_index.py
+++ b/src/documents/management/commands/document_index.py
@@ -1,6 +1,7 @@
 from django.core.management import BaseCommand
 from django.db import transaction
 
+from documents.index import recreate_index_dir
 from documents.management.commands.mixins import ProgressBarMixin
 from documents.tasks import index_optimize
 from documents.tasks import index_reindex
@@ -17,6 +18,7 @@ class Command(ProgressBarMixin, BaseCommand):
         self.handle_progress_bar_mixin(**options)
         with transaction.atomic():
             if options["command"] == "reindex":
+                recreate_index_dir()
                 index_reindex(progress_bar_disable=self.no_progress_bar)
             elif options["command"] == "optimize":
                 index_optimize()

--- a/src/documents/serialisers.py
+++ b/src/documents/serialisers.py
@@ -1268,9 +1268,11 @@ class DocumentSerializer(
 
 class SearchResultListSerializer(serializers.ListSerializer):
     def to_representation(self, hits):
+        # print(f"hits: {hits}")
         document_ids = [hit["id"] for hit in hits]
         # Fetch all Document objects in the list in one SQL query.
         documents = self.child.fetch_documents(document_ids)
+        # print(documents)
         self.child.context["documents"] = documents
         # Also check if they are shared with other users / groups.
         self.child.context["shared_object_pks"] = self.child.get_shared_object_pks(
@@ -1312,12 +1314,16 @@ class SearchResultSerializer(DocumentSerializer):
             [str(c.note) for c in document.notes.all()],
         )
         r = super().to_representation(document)
+
+        highlights = hit.highlights("content")
+        note_highlights = hit.highlights("notes")
+        score = (
+            hit.score if highlights else None
+        )  # Hide score in front-end if no text highlight
         r["__search_hit__"] = {
-            "score": hit.score,
-            "highlights": hit.highlights("content", text=document.content),
-            "note_highlights": (
-                hit.highlights("notes", text=notes) if document else None
-            ),
+            "score": score,
+            "highlights": highlights,
+            "note_highlights": note_highlights,
             "rank": hit.rank,
         }
 

--- a/src/documents/serialisers.py
+++ b/src/documents/serialisers.py
@@ -1309,12 +1309,7 @@ class SearchResultSerializer(DocumentSerializer):
             # I'm keeping this check for completeness but marking it no cover for now.
             documents = self.fetch_documents([hit["id"]])
         document = documents[hit["id"]]
-
-        notes = ",".join(
-            [str(c.note) for c in document.notes.all()],
-        )
         r = super().to_representation(document)
-
         highlights = hit.highlights("content")
         note_highlights = hit.highlights("notes")
         score = (

--- a/src/documents/tasks.py
+++ b/src/documents/tasks.py
@@ -120,6 +120,7 @@ def index_reindex(*, progress_bar_disable=False) -> None:
                         writer,
                         document,
                         viewer_ids=viewer_map.get(document.pk, []),
+                        skip_delete=True,
                     )
                     progress_bar.update(1)
 

--- a/src/documents/tasks.py
+++ b/src/documents/tasks.py
@@ -101,30 +101,32 @@ def index_reindex(*, progress_bar_disable=False) -> None:
         "owner",
     ).order_by("pk")
 
-    with index.open_index_writer(recreate=True) as writer:
-        with tqdm.tqdm(total=total, disable=progress_bar_disable) as progress_bar:
-            last_pk = 0
-            while True:
-                chunk = list(base_qs.filter(pk__gt=last_pk)[:chunk_size])
-                if not chunk:
-                    break
+    with (
+        index.open_index_writer(recreate=True) as writer,
+        tqdm.tqdm(total=total, disable=progress_bar_disable) as progress_bar,
+    ):
+        last_pk = 0
+        while True:
+            chunk = list(base_qs.filter(pk__gt=last_pk)[:chunk_size])
+            if not chunk:
+                break
 
-                prefetch_related_objects(chunk, "tags", "notes", "custom_fields__field")
+            prefetch_related_objects(chunk, "tags", "notes", "custom_fields__field")
 
-                # Bulk-fetch permissions: 1 query per chunk instead of 1 per doc
-                chunk_pks = [doc.pk for doc in chunk]
-                viewer_map = _bulk_get_viewer_ids(chunk_pks)
+            # Bulk-fetch permissions: 1 query per chunk instead of 1 per doc
+            chunk_pks = [doc.pk for doc in chunk]
+            viewer_map = _bulk_get_viewer_ids(chunk_pks)
 
-                for document in chunk:
-                    index.update_document(
-                        writer,
-                        document,
-                        viewer_ids=viewer_map.get(document.pk, []),
-                        skip_delete=True,
-                    )
-                    progress_bar.update(1)
+            for document in chunk:
+                index.update_document(
+                    writer,
+                    document,
+                    viewer_ids=viewer_map.get(document.pk, []),
+                    skip_delete=True,
+                )
+                progress_bar.update(1)
 
-                last_pk = chunk[-1].pk
+            last_pk = chunk[-1].pk
 
 
 @shared_task

--- a/src/documents/tasks.py
+++ b/src/documents/tasks.py
@@ -18,7 +18,6 @@ from django.db.models import prefetch_related_objects
 from django.db.models.signals import post_save
 from django.utils import timezone
 from filelock import FileLock
-from whoosh.writing import AsyncWriter
 
 from documents import index
 from documents import sanity_checker
@@ -63,9 +62,11 @@ logger = logging.getLogger("paperless.tasks")
 
 @shared_task
 def index_optimize():
-    ix = index.open_index()
-    writer = AsyncWriter(ix)
-    writer.commit(optimize=True)
+    # Currently the Tantivy Python binder doesn't allow to change merge policy.
+    # So this is currently a no-op and my even be removed in the future.
+    # See https://tantivy-py.readthedocs.io/en/latest/explanation/#merge-policy
+    # See also https://fulmicoton.com/posts/behold-tantivy-part2/
+    logger.info("Index is already optimized. Nothing to do.")
 
 
 def _bulk_get_viewer_ids(doc_pks):
@@ -279,8 +280,6 @@ def sanity_check(*, scheduled=True, raise_on_error=True):
 def bulk_update_documents(document_ids):
     documents = Document.objects.filter(id__in=document_ids)
 
-    ix = index.open_index()
-
     for doc in documents:
         clear_document_caches(doc.pk)
         document_updated.send(
@@ -290,7 +289,7 @@ def bulk_update_documents(document_ids):
         )
         post_save.send(Document, instance=doc, created=False)
 
-    with AsyncWriter(ix) as writer:
+    with index.open_index_writer() as writer:
         for doc in documents:
             index.update_document(writer, doc)
 

--- a/src/documents/tasks.py
+++ b/src/documents/tasks.py
@@ -14,6 +14,7 @@ from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.db import models
 from django.db import transaction
+from django.db.models import prefetch_related_objects
 from django.db.models.signals import post_save
 from django.utils import timezone
 from filelock import FileLock
@@ -67,14 +68,32 @@ def index_optimize():
     writer.commit(optimize=True)
 
 
-def index_reindex(*, progress_bar_disable=False):
-    documents = Document.objects.all()
+def index_reindex(*, progress_bar_disable=False) -> None:
+    total = Document.objects.count()
+    chunk_size = 1000  # Load docs from DB in RAM by chunks
 
-    ix = index.open_index(recreate=True)
+    base_qs = Document.objects.select_related(
+        "correspondent",
+        "document_type",
+        "storage_path",
+        "owner",
+    ).order_by("pk")
 
-    with AsyncWriter(ix) as writer:
-        for document in tqdm.tqdm(documents, disable=progress_bar_disable):
-            index.update_document(writer, document)
+    with index.open_index_writer() as writer:
+        with tqdm.tqdm(total=total, disable=progress_bar_disable) as progress_bar:
+            last_pk = 0
+            while True:
+                chunk = list(base_qs.filter(pk__gt=last_pk)[:chunk_size])
+                if not chunk:
+                    break
+
+                prefetch_related_objects(chunk, "tags", "notes", "custom_fields__field")
+
+                for document in chunk:
+                    index.update_document(writer, document)
+                    progress_bar.update(1)
+
+                last_pk = chunk[-1].pk
 
 
 @shared_task

--- a/src/documents/tasks.py
+++ b/src/documents/tasks.py
@@ -68,6 +68,28 @@ def index_optimize():
     writer.commit(optimize=True)
 
 
+def _bulk_get_viewer_ids(doc_pks):
+    """Fetch all view_document permissions for a batch of documents in one query."""
+    from collections import defaultdict
+
+    from django.contrib.auth.models import Permission
+    from guardian.models import UserObjectPermission
+
+    ct = ContentType.objects.get_for_model(Document)
+    perm = Permission.objects.get(content_type=ct, codename="view_document")
+
+    qs = UserObjectPermission.objects.filter(
+        content_type=ct,
+        permission=perm,
+        object_pk__in=[str(pk) for pk in doc_pks],
+    ).values_list("object_pk", "user_id")
+
+    viewer_map = defaultdict(list)
+    for object_pk, user_id in qs:
+        viewer_map[int(object_pk)].append(user_id)
+    return viewer_map
+
+
 def index_reindex(*, progress_bar_disable=False) -> None:
     total = Document.objects.count()
     chunk_size = 1000  # Load docs from DB in RAM by chunks
@@ -89,8 +111,16 @@ def index_reindex(*, progress_bar_disable=False) -> None:
 
                 prefetch_related_objects(chunk, "tags", "notes", "custom_fields__field")
 
+                # Bulk-fetch permissions: 1 query per chunk instead of 1 per doc
+                chunk_pks = [doc.pk for doc in chunk]
+                viewer_map = _bulk_get_viewer_ids(chunk_pks)
+
                 for document in chunk:
-                    index.update_document(writer, document)
+                    index.update_document(
+                        writer,
+                        document,
+                        viewer_ids=viewer_map.get(document.pk, []),
+                    )
                     progress_bar.update(1)
 
                 last_pk = chunk[-1].pk

--- a/src/documents/tasks.py
+++ b/src/documents/tasks.py
@@ -101,7 +101,7 @@ def index_reindex(*, progress_bar_disable=False) -> None:
         "owner",
     ).order_by("pk")
 
-    with index.open_index_writer() as writer:
+    with index.open_index_writer(recreate=True) as writer:
         with tqdm.tqdm(total=total, disable=progress_bar_disable) as progress_bar:
             last_pk = 0
             while True:

--- a/src/documents/tests/test_admin.py
+++ b/src/documents/tests/test_admin.py
@@ -19,9 +19,16 @@ from paperless.admin import PaperlessUserAdmin
 
 class TestDocumentAdmin(DirectoriesMixin, TestCase):
     def get_document_from_index(self, doc):
-        ix = index.open_index()
-        with ix.searcher() as searcher:
-            return searcher.document(id=doc.id)
+        """Look up a document in the Tantivy index by its id. Returns the doc dict or None."""
+        import tantivy
+
+        with index.open_index() as ix:
+            searcher = ix.searcher()
+            query = tantivy.Query.term_query(index.get_schema(), "id", doc.id)
+            result = searcher.search(query, limit=1)
+            if result.hits:
+                return searcher.doc(result.hits[0][1])
+            return None
 
     def setUp(self) -> None:
         super().setUp()
@@ -33,7 +40,7 @@ class TestDocumentAdmin(DirectoriesMixin, TestCase):
         doc.title = "new title"
         self.doc_admin.save_model(None, doc, None, None)
         self.assertEqual(Document.objects.get(id=doc.id).title, "new title")
-        self.assertEqual(self.get_document_from_index(doc)["id"], doc.id)
+        self.assertEqual(self.get_document_from_index(doc)["id"][0], doc.id)
 
     def test_delete_model(self):
         doc = Document.objects.create(title="test")

--- a/src/documents/tests/test_api_search.py
+++ b/src/documents/tests/test_api_search.py
@@ -1191,10 +1191,7 @@ class TestDocumentSearchApi(DirectoriesMixin, APITestCase):
             document=d3,
             user=u1,
         )
-
-        with index.open_index_writer() as writer:
-            for doc in Document.objects.all():
-                index.update_document(writer, doc)
+        index.add_or_update_documents(Document.objects.all())
 
         def search_query(q):
             r = self.client.get("/api/documents/?query=test" + q)

--- a/src/documents/tests/test_api_search.py
+++ b/src/documents/tests/test_api_search.py
@@ -11,7 +11,6 @@ from django.utils import timezone
 from guardian.shortcuts import assign_perm
 from rest_framework import status
 from rest_framework.test import APITestCase
-from whoosh.writing import AsyncWriter
 
 from documents import index
 from documents.bulk_edit import set_permissions
@@ -57,7 +56,7 @@ class TestDocumentSearchApi(DirectoriesMixin, APITestCase):
             checksum="C",
             original_filename="someepdf.pdf",
         )
-        with AsyncWriter(index.open_index()) as writer:
+        with index.open_index_writer() as writer:
             # Note to future self: there is a reason we dont use a model signal handler to update the index: some operations edit many documents at once
             # (retagger, renamer) and we don't want to open a writer for each of these, but rather perform the entire operation with one writer.
             # That's why we can't open the writer in a model on_save handler or something.
@@ -125,7 +124,7 @@ class TestDocumentSearchApi(DirectoriesMixin, APITestCase):
             value_int=20,
         )
 
-        with AsyncWriter(index.open_index()) as writer:
+        with index.open_index_writer() as writer:
             index.update_document(writer, d1)
             index.update_document(writer, d2)
             index.update_document(writer, d3)
@@ -149,7 +148,7 @@ class TestDocumentSearchApi(DirectoriesMixin, APITestCase):
         )
 
     def test_search_multi_page(self):
-        with AsyncWriter(index.open_index()) as writer:
+        with index.open_index_writer() as writer:
             for i in range(55):
                 doc = Document.objects.create(
                     checksum=str(i),
@@ -184,7 +183,7 @@ class TestDocumentSearchApi(DirectoriesMixin, APITestCase):
             seen_ids.append(result["id"])
 
     def test_search_invalid_page(self):
-        with AsyncWriter(index.open_index()) as writer:
+        with index.open_index_writer() as writer:
             for i in range(15):
                 doc = Document.objects.create(
                     checksum=str(i),
@@ -609,7 +608,7 @@ class TestDocumentSearchApi(DirectoriesMixin, APITestCase):
             owner=u1,
         )
 
-        with AsyncWriter(index.open_index()) as writer:
+        with index.open_index_writer() as writer:
             index.update_document(writer, d1)
             index.update_document(writer, d2)
             index.update_document(writer, d3)
@@ -620,7 +619,7 @@ class TestDocumentSearchApi(DirectoriesMixin, APITestCase):
 
         d3.owner = u2
 
-        with AsyncWriter(index.open_index()) as writer:
+        with index.open_index_writer() as writer:
             index.update_document(writer, d3)
 
         response = self.client.get("/api/search/autocomplete/?term=app")
@@ -629,7 +628,7 @@ class TestDocumentSearchApi(DirectoriesMixin, APITestCase):
 
         assign_perm("view_document", u1, d3)
 
-        with AsyncWriter(index.open_index()) as writer:
+        with index.open_index_writer() as writer:
             index.update_document(writer, d3)
 
         response = self.client.get("/api/search/autocomplete/?term=app")
@@ -652,7 +651,7 @@ class TestDocumentSearchApi(DirectoriesMixin, APITestCase):
             checksum="1",
         )
 
-        with AsyncWriter(index.open_index()) as writer:
+        with index.open_index_writer() as writer:
             index.update_document(writer, d1)
 
         response = self.client.get("/api/search/autocomplete/?term=created:2023")
@@ -674,7 +673,7 @@ class TestDocumentSearchApi(DirectoriesMixin, APITestCase):
             checksum="1",
         )
 
-        with AsyncWriter(index.open_index()) as writer:
+        with index.open_index_writer() as writer:
             index.update_document(writer, d1)
 
         response = self.client.get("/api/search/autocomplete/?term=auto")
@@ -682,7 +681,7 @@ class TestDocumentSearchApi(DirectoriesMixin, APITestCase):
         self.assertEqual(response.data[0], b"auto")
 
     def test_search_spelling_suggestion(self):
-        with AsyncWriter(index.open_index()) as writer:
+        with index.open_index_writer() as writer:
             for i in range(55):
                 doc = Document.objects.create(
                     checksum=str(i),
@@ -756,7 +755,7 @@ class TestDocumentSearchApi(DirectoriesMixin, APITestCase):
             pk=4,
             checksum="ABC",
         )
-        with AsyncWriter(index.open_index()) as writer:
+        with index.open_index_writer() as writer:
             index.update_document(writer, d1)
             index.update_document(writer, d2)
             index.update_document(writer, d3)
@@ -835,7 +834,7 @@ class TestDocumentSearchApi(DirectoriesMixin, APITestCase):
             value_text="foobard4",
         )
 
-        with AsyncWriter(index.open_index()) as writer:
+        with index.open_index_writer() as writer:
             for doc in Document.objects.all():
                 index.update_document(writer, doc)
 
@@ -1053,7 +1052,7 @@ class TestDocumentSearchApi(DirectoriesMixin, APITestCase):
         Document.objects.create(checksum="3", content="test 3", owner=u2)
         Document.objects.create(checksum="4", content="test 4")
 
-        with AsyncWriter(index.open_index()) as writer:
+        with index.open_index_writer() as writer:
             for doc in Document.objects.all():
                 index.update_document(writer, doc)
 
@@ -1106,7 +1105,7 @@ class TestDocumentSearchApi(DirectoriesMixin, APITestCase):
         d3 = Document.objects.create(checksum="3", content="test 3", owner=u2)
         Document.objects.create(checksum="4", content="test 4")
 
-        with AsyncWriter(index.open_index()) as writer:
+        with index.open_index_writer() as writer:
             for doc in Document.objects.all():
                 index.update_document(writer, doc)
 
@@ -1128,7 +1127,7 @@ class TestDocumentSearchApi(DirectoriesMixin, APITestCase):
         assign_perm("view_document", u1, d3)
         assign_perm("view_document", u2, d1)
 
-        with AsyncWriter(index.open_index()) as writer:
+        with index.open_index_writer() as writer:
             for doc in [d1, d2, d3]:
                 index.update_document(writer, doc)
 
@@ -1193,7 +1192,7 @@ class TestDocumentSearchApi(DirectoriesMixin, APITestCase):
             user=u1,
         )
 
-        with AsyncWriter(index.open_index()) as writer:
+        with index.open_index_writer() as writer:
             for doc in Document.objects.all():
                 index.update_document(writer, doc)
 

--- a/src/documents/tests/test_api_search.py
+++ b/src/documents/tests/test_api_search.py
@@ -702,7 +702,7 @@ class TestDocumentSearchApi(DirectoriesMixin, APITestCase):
         self.assertEqual(correction, None)
 
     @mock.patch(
-        "whoosh.searching.Searcher.correct_query",
+        "documents.index.autocomplete",
         side_effect=Exception("Test error"),
     )
     def test_corrected_query_error(self, mock_correct_query):

--- a/src/documents/tests/test_api_status.py
+++ b/src/documents/tests/test_api_status.py
@@ -151,8 +151,7 @@ class TestSystemStatus(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["tasks"]["celery_status"], "OK")
 
-    @override_settings(INDEX_DIR=Path("/tmp/index"))
-    @mock.patch("whoosh.index.FileIndex.last_modified")
+    @mock.patch("documents.index.get_index_last_modified")
     def test_system_status_index_ok(self, mock_last_modified):
         """
         GIVEN:

--- a/src/documents/tests/test_index.py
+++ b/src/documents/tests/test_index.py
@@ -32,13 +32,13 @@ class TestAutoComplete(DirectoriesMixin, TestCase):
         with index.open_index() as ix:
             self.assertListEqual(
                 index.autocomplete(ix, "tes"),
-                ["test2", "test", "test3"],
+                [b"test2", b"test", b"test3"],
             )
             self.assertListEqual(
                 index.autocomplete(ix, "tes", limit=3),
-                ["test2", "test", "test3"],
+                [b"test2", b"test", b"test3"],
             )
-            self.assertListEqual(index.autocomplete(ix, "tes", limit=1), ["test2"])
+            self.assertListEqual(index.autocomplete(ix, "tes", limit=1), [b"test2"])
             self.assertListEqual(index.autocomplete(ix, "tes", limit=0), [])
 
     def test_archive_serial_number_ranging(self):

--- a/src/documents/tests/test_index.py
+++ b/src/documents/tests/test_index.py
@@ -32,13 +32,13 @@ class TestAutoComplete(DirectoriesMixin, TestCase):
 
         self.assertListEqual(
             index.autocomplete(ix, "tes"),
-            [b"test2", b"test", b"test3"],
+            ["test2", "test", "test3"],
         )
         self.assertListEqual(
             index.autocomplete(ix, "tes", limit=3),
-            [b"test2", b"test", b"test3"],
+            ["test2", "test", "test3"],
         )
-        self.assertListEqual(index.autocomplete(ix, "tes", limit=1), [b"test2"])
+        self.assertListEqual(index.autocomplete(ix, "tes", limit=1), ["test2"])
         self.assertListEqual(index.autocomplete(ix, "tes", limit=0), [])
 
     def test_archive_serial_number_ranging(self):
@@ -61,14 +61,14 @@ class TestAutoComplete(DirectoriesMixin, TestCase):
         )
         with self.assertLogs("paperless.index", level="ERROR") as cm:
             with mock.patch(
-                "documents.index.AsyncWriter.update_document",
-            ) as mocked_update_doc:
+                "documents.index.AsyncWriter.add_document",
+            ) as mocked_add_doc:
                 index.add_or_update_document(doc1)
 
-                mocked_update_doc.assert_called_once()
-                _, kwargs = mocked_update_doc.call_args
+                mocked_add_doc.assert_called_once()
+                indexed_doc = mocked_add_doc.call_args[0][0]
 
-                self.assertEqual(kwargs["asn"], 0)
+                self.assertEqual(indexed_doc["asn"], [0])
 
                 error_str = cm.output[0]
                 expected_str = "ERROR:paperless.index:Not indexing Archive Serial Number 4294967296 of document 1"
@@ -81,7 +81,7 @@ class TestAutoComplete(DirectoriesMixin, TestCase):
         WHEN:
             - Document is provided to the index
         THEN:
-            - ASN isn't touched
+            - ASN is set to 0 in the index
         """
         doc1 = Document.objects.create(
             title="doc1",
@@ -89,14 +89,14 @@ class TestAutoComplete(DirectoriesMixin, TestCase):
             content="test test2 test3",
         )
         with mock.patch(
-            "documents.index.AsyncWriter.update_document",
-        ) as mocked_update_doc:
+            "documents.index.AsyncWriter.add_document",
+        ) as mocked_add_doc:
             index.add_or_update_document(doc1)
 
-            mocked_update_doc.assert_called_once()
-            _, kwargs = mocked_update_doc.call_args
+            mocked_add_doc.assert_called_once()
+            indexed_doc = mocked_add_doc.call_args[0][0]
 
-            self.assertIsNone(kwargs["asn"])
+            self.assertEqual(indexed_doc["asn"], [0])
 
     @override_settings(TIME_ZONE="Pacific/Auckland")
     def test_added_today_respects_local_timezone_boundary(self):

--- a/src/documents/tests/test_index.py
+++ b/src/documents/tests/test_index.py
@@ -29,18 +29,17 @@ class TestAutoComplete(DirectoriesMixin, TestCase):
         index.add_or_update_document(doc2)
         index.add_or_update_document(doc3)
 
-        ix = index.open_index()
-
-        self.assertListEqual(
-            index.autocomplete(ix, "tes"),
-            ["test2", "test", "test3"],
-        )
-        self.assertListEqual(
-            index.autocomplete(ix, "tes", limit=3),
-            ["test2", "test", "test3"],
-        )
-        self.assertListEqual(index.autocomplete(ix, "tes", limit=1), ["test2"])
-        self.assertListEqual(index.autocomplete(ix, "tes", limit=0), [])
+        with index.open_index() as ix:
+            self.assertListEqual(
+                index.autocomplete(ix, "tes"),
+                ["test2", "test", "test3"],
+            )
+            self.assertListEqual(
+                index.autocomplete(ix, "tes", limit=3),
+                ["test2", "test", "test3"],
+            )
+            self.assertListEqual(index.autocomplete(ix, "tes", limit=1), ["test2"])
+            self.assertListEqual(index.autocomplete(ix, "tes", limit=0), [])
 
     def test_archive_serial_number_ranging(self):
         """

--- a/src/documents/tests/test_index.py
+++ b/src/documents/tests/test_index.py
@@ -160,44 +160,60 @@ class TestRewriteNaturalDateKeywords(SimpleTestCase):
             (
                 "added:today",
                 datetime(2025, 7, 20, 15, 30, 45, tzinfo=timezone.utc),
-                ("added:[20250720", "TO 20250720"),
+                (
+                    "added:[2025-07-20T00:00:00+00:00 TO 2025-07-20T23:59:59.999999+00:00]",
+                ),
             ),
             (
                 "added:yesterday",
                 datetime(2025, 7, 20, 15, 30, 45, tzinfo=timezone.utc),
-                ("added:[20250719", "TO 20250719"),
+                (
+                    "added:[2025-07-19T00:00:00+00:00 TO 2025-07-19T23:59:59.999999+00:00]",
+                ),
             ),
             (
                 "added:this month",
                 datetime(2025, 7, 15, 12, 0, 0, tzinfo=timezone.utc),
-                ("added:[20250701", "TO 20250731"),
+                (
+                    "added:[2025-07-01T00:00:00+00:00 TO 2025-07-31T23:59:59.999999+00:00]",
+                ),
             ),
             (
                 "added:previous month",
                 datetime(2025, 7, 15, 12, 0, 0, tzinfo=timezone.utc),
-                ("added:[20250601", "TO 20250630"),
+                (
+                    "added:[2025-06-01T00:00:00+00:00 TO 2025-06-30T23:59:59.999999+00:00]",
+                ),
             ),
             (
                 "added:this year",
                 datetime(2025, 7, 15, 12, 0, 0, tzinfo=timezone.utc),
-                ("added:[20250101", "TO 20251231"),
+                (
+                    "added:[2025-01-01T00:00:00+00:00 TO 2025-12-31T23:59:59.999999+00:00]",
+                ),
             ),
             (
                 "added:previous year",
                 datetime(2025, 7, 15, 12, 0, 0, tzinfo=timezone.utc),
-                ("added:[20240101", "TO 20241231"),
+                (
+                    "added:[2024-01-01T00:00:00+00:00 TO 2024-12-31T23:59:59.999999+00:00]",
+                ),
             ),
             # Previous quarter from July 15, 2025 is April-June.
             (
                 "added:previous quarter",
                 datetime(2025, 7, 15, 12, 0, 0, tzinfo=timezone.utc),
-                ("added:[20250401", "TO 20250630"),
+                (
+                    "added:[2025-04-01T00:00:00+00:00 TO 2025-06-30T23:59:59.999999+00:00]",
+                ),
             ),
             # July 20, 2025 is a Sunday (weekday 6) so previous week is July 7-13.
             (
                 "added:previous week",
                 datetime(2025, 7, 20, 12, 0, 0, tzinfo=timezone.utc),
-                ("added:[20250707", "TO 20250713"),
+                (
+                    "added:[2025-07-07T00:00:00+00:00 TO 2025-07-13T23:59:59.999999+00:00]",
+                ),
             ),
         ]
 
@@ -208,9 +224,13 @@ class TestRewriteNaturalDateKeywords(SimpleTestCase):
     def test_additional_fields(self):
         fixed_now = datetime(2025, 7, 20, 15, 30, 45, tzinfo=timezone.utc)
         # created
-        self._assert_rewrite_contains("created:today", fixed_now, "created:[20250720")
+        self._assert_rewrite_contains("created:today", fixed_now, "created:[2025-07-20")
         # modified
-        self._assert_rewrite_contains("modified:today", fixed_now, "modified:[20250720")
+        self._assert_rewrite_contains(
+            "modified:today",
+            fixed_now,
+            "modified:[2025-07-20",
+        )
 
     def test_basic_syntax_variants(self):
         """
@@ -221,18 +241,18 @@ class TestRewriteNaturalDateKeywords(SimpleTestCase):
         # quoted keywords
         result1 = self._rewrite_with_now('added:"today"', fixed_now)
         result2 = self._rewrite_with_now("added:'today'", fixed_now)
-        self.assertIn("added:[20250720", result1)
-        self.assertIn("added:[20250720", result2)
+        self.assertIn("added:[2025-07-20", result1)
+        self.assertIn("added:[2025-07-20", result2)
 
         # case insensitivity
         for query in ("added:TODAY", "added:Today", "added:ToDaY"):
             with self.subTest(case_variant=query):
-                self._assert_rewrite_contains(query, fixed_now, "added:[20250720")
+                self._assert_rewrite_contains(query, fixed_now, "added:[2025-07-20")
 
         # multiple clauses
         result = self._rewrite_with_now("added:today created:yesterday", fixed_now)
-        self.assertIn("added:[20250720", result)
-        self.assertIn("created:[20250719", result)
+        self.assertIn("added:[2025-07-20", result)
+        self.assertIn("created:[2025-07-19", result)
 
     def test_no_match(self):
         """
@@ -251,7 +271,11 @@ class TestRewriteNaturalDateKeywords(SimpleTestCase):
         fixed_now = datetime(2025, 7, 20, 1, 0, 0, tzinfo=get_current_timezone())
         result = self._rewrite_with_now("added:today", fixed_now)
         # Should convert to UTC properly
-        self.assertIn("added:[20250719", result)
+        # NZST is UTC+12, so "today" July 20 local = July 19 12:00 UTC to July 20 11:59:59 UTC
+        self.assertIn(
+            "added:[2025-07-19T12:00:00+00:00 TO 2025-07-20T11:59:59.999999+00:00]",
+            result,
+        )
 
 
 class TestIndexResilience(DirectoriesMixin, SimpleTestCase):

--- a/src/documents/tests/test_index.py
+++ b/src/documents/tests/test_index.py
@@ -129,6 +129,30 @@ class TestAutoComplete(DirectoriesMixin, TestCase):
             results = response.json()["results"]
             self.assertEqual(len(results), 0)
 
+    def test_update_doc_replaces_previous_one(self):
+        """
+        GIVEN:
+            - Any document
+        WHEN:
+            - Document is added to the index
+        THEN:
+            - Any document with the same ID is removed from the index
+        """
+        doc1 = Document.objects.create(
+            id=123,
+            title="doc1",
+            checksum="A",
+            content="test test2 test3",
+        )
+        with mock.patch(
+            "documents.index.remove_document_by_id",
+        ) as mocked_remove_doc:
+            index.add_or_update_document(doc1)
+
+            mocked_remove_doc.assert_called_once()
+            doc_id = mocked_remove_doc.call_args[0][1]
+            self.assertEqual(doc_id, 123)
+
 
 @override_settings(TIME_ZONE="UTC")
 class TestRewriteNaturalDateKeywords(SimpleTestCase):

--- a/src/documents/tests/test_index.py
+++ b/src/documents/tests/test_index.py
@@ -1,7 +1,6 @@
 from datetime import datetime
 from unittest import mock
 
-from django.conf import settings
 from django.contrib.auth.models import User
 from django.test import SimpleTestCase
 from django.test import TestCase
@@ -279,48 +278,35 @@ class TestRewriteNaturalDateKeywords(SimpleTestCase):
 
 
 class TestIndexResilience(DirectoriesMixin, SimpleTestCase):
-    def _assert_recreate_called(self, mock_create_in):
-        mock_create_in.assert_called_once()
-        path_arg, schema_arg = mock_create_in.call_args.args
-        self.assertEqual(path_arg, settings.INDEX_DIR)
-        self.assertEqual(schema_arg.__class__.__name__, "Schema")
-
-    def test_transient_missing_segment_does_not_force_recreate(self):
+    def test_transient_error_retries_then_succeeds(self):
         """
         GIVEN:
             - Index directory exists
         WHEN:
             - open_index is called
-            - Opening the index raises FileNotFoundError once due to a
-              transient missing segment
+            - tantivy.Index raises OSError once, then succeeds
         THEN:
             - Index is opened successfully on retry
             - Index is not recreated
         """
-        file_marker = settings.INDEX_DIR / "file_marker.txt"
-        file_marker.write_text("keep")
-        expected_index = object()
+        expected_index = mock.MagicMock()
 
         with (
-            mock.patch("documents.index.exists_in", return_value=True),
+            self.assertLogs("paperless.index", level="WARNING") as cm,
             mock.patch(
-                "documents.index.open_dir",
-                side_effect=[FileNotFoundError("missing"), expected_index],
-            ) as mock_open_dir,
-            mock.patch(
-                "documents.index.create_in",
-            ) as mock_create_in,
-            mock.patch(
-                "documents.index.rmtree",
-            ) as mock_rmtree,
+                "documents.index.tantivy.Index",
+                side_effect=[OSError("busy"), expected_index],
+            ) as mock_index,
+            mock.patch("documents.index.recreate_index_dir") as mock_recreate,
         ):
-            ix = index.open_index()
+            with index.open_index() as ix:
+                self.assertIs(ix, expected_index)
 
-        self.assertIs(ix, expected_index)
-        self.assertGreaterEqual(mock_open_dir.call_count, 2)
-        mock_rmtree.assert_not_called()
-        mock_create_in.assert_not_called()
-        self.assertEqual(file_marker.read_text(), "keep")
+        self.assertEqual(mock_index.call_count, 2)
+        # recreate_index_dir is only called at the start if path doesn't exist
+        # but not as error recovery since retry succeeded
+        mock_recreate.assert_not_called()
+        self.assertIn("Error opening index (attempt 1/3)", cm.output[0])
 
     def test_transient_errors_exhaust_retries_and_recreate(self):
         """
@@ -328,68 +314,57 @@ class TestIndexResilience(DirectoriesMixin, SimpleTestCase):
             - Index directory exists
         WHEN:
             - open_index is called
-            - Opening the index raises FileNotFoundError multiple times due to
-              transient missing segments
+            - tantivy.Index always raises OSError
         THEN:
             - Index is recreated after retries are exhausted
         """
-        recreated_index = object()
+        recreated_index = mock.MagicMock()
 
         with (
             self.assertLogs("paperless.index", level="ERROR") as cm,
-            mock.patch("documents.index.exists_in", return_value=True),
             mock.patch(
-                "documents.index.open_dir",
-                side_effect=FileNotFoundError("missing"),
-            ) as mock_open_dir,
-            mock.patch("documents.index.rmtree") as mock_rmtree,
-            mock.patch(
-                "documents.index.create_in",
-                return_value=recreated_index,
-            ) as mock_create_in,
+                "documents.index.tantivy.Index",
+                side_effect=[
+                    OSError("busy"),
+                    OSError("busy"),
+                    OSError("busy"),
+                    recreated_index,
+                ],
+            ) as mock_index,
+            mock.patch("documents.index.recreate_index_dir") as mock_recreate,
         ):
-            ix = index.open_index()
+            with index.open_index() as ix:
+                self.assertIs(ix, recreated_index)
 
-        self.assertIs(ix, recreated_index)
-        self.assertEqual(mock_open_dir.call_count, 4)
-        mock_rmtree.assert_called_once_with(settings.INDEX_DIR)
-        self._assert_recreate_called(mock_create_in)
-        self.assertIn(
-            "Error while opening the index after retries, recreating.",
-            cm.output[0],
-        )
+        # 3 failed attempts + 1 final call after recreate
+        self.assertEqual(mock_index.call_count, 4)
+        mock_recreate.assert_called_once()
+        self.assertIn("Failed to open index after 3 attempts", cm.output[-1])
 
-    def test_non_transient_error_recreates_index(self):
+    def test_schema_error_recreates_immediately(self):
         """
         GIVEN:
             - Index directory exists
         WHEN:
             - open_index is called
-            - Opening the index raises a "non-transient" error
+            - tantivy.Index raises ValueError (schema mismatch)
         THEN:
-            - Index is recreated
+            - Index is recreated immediately without retries
         """
-        recreated_index = object()
+        recreated_index = mock.MagicMock()
 
         with (
-            self.assertLogs("paperless.index", level="ERROR") as cm,
-            mock.patch("documents.index.exists_in", return_value=True),
+            self.assertLogs("paperless.index", level="WARNING") as cm,
             mock.patch(
-                "documents.index.open_dir",
-                side_effect=RuntimeError("boom"),
-            ),
-            mock.patch("documents.index.rmtree") as mock_rmtree,
-            mock.patch(
-                "documents.index.create_in",
-                return_value=recreated_index,
-            ) as mock_create_in,
+                "documents.index.tantivy.Index",
+                side_effect=[ValueError("schema changed"), recreated_index],
+            ) as mock_index,
+            mock.patch("documents.index.recreate_index_dir") as mock_recreate,
         ):
-            ix = index.open_index()
+            with index.open_index() as ix:
+                self.assertIs(ix, recreated_index)
 
-        self.assertIs(ix, recreated_index)
-        mock_rmtree.assert_called_once_with(settings.INDEX_DIR)
-        self._assert_recreate_called(mock_create_in)
-        self.assertIn(
-            "Error while opening the index, recreating.",
-            cm.output[0],
-        )
+        # 1 failed attempt + 1 call after recreate = 2
+        self.assertEqual(mock_index.call_count, 2)
+        mock_recreate.assert_called_once()
+        self.assertIn("Recreating index due to schema error", cm.output[0])

--- a/src/documents/tests/test_index.py
+++ b/src/documents/tests/test_index.py
@@ -9,6 +9,8 @@ from django.utils.timezone import get_current_timezone
 from django.utils.timezone import timezone
 
 from documents import index
+from documents.index import normalize_query
+from documents.index import preprocess_query
 from documents.models import Document
 from documents.tests.utils import DirectoriesMixin
 
@@ -392,3 +394,399 @@ class TestIndexResilience(DirectoriesMixin, SimpleTestCase):
         self.assertEqual(mock_index.call_count, 2)
         mock_recreate.assert_called_once()
         self.assertIn("Recreating index due to schema error", cm.output[0])
+
+
+class TestNormalizeQuery(SimpleTestCase):
+    """normalize_query: comma-separated parts → AND joins."""
+
+    def test_single_term_no_comma(self):
+        self.assertEqual(normalize_query("invoice"), "(invoice)")
+
+    def test_comma_separated_free_text(self):
+        self.assertEqual(normalize_query("bank, statement"), "(bank statement)")
+
+    def test_comma_with_field_filter(self):
+        self.assertEqual(
+            normalize_query("bank statement, added:today"),
+            "(bank statement) AND added:today",
+        )
+
+    def test_multiple_field_filters(self):
+        self.assertEqual(
+            normalize_query("added:today, created:yesterday"),
+            "added:today AND created:yesterday",
+        )
+
+    def test_mixed_free_text_and_filters(self):
+        self.assertEqual(
+            normalize_query("invoice, tag:important, bank"),
+            "(invoice) AND tag:important AND (bank)",
+        )
+
+    def test_empty_string(self):
+        self.assertEqual(normalize_query(""), "")
+
+    def test_whitespace_parts_ignored(self):
+        self.assertEqual(normalize_query("test, , ,hello"), "(test hello)")
+
+
+class TestTantivyQueryParsing(DirectoriesMixin, SimpleTestCase):
+    """
+    Integration tests: verify that Tantivy's parse_query_lenient correctly
+    interprets boolean operators, phrases, ranges, field queries, and boosting.
+
+    Opens a real (empty) Tantivy index and inspects generated query structure.
+    """
+
+    default_fields = [
+        "content",
+        "title",
+        "correspondent",
+        "tag",
+        "type",
+        "notes",
+        "custom_fields",
+    ]
+
+    def _parse(self, query_str, *, conjunction_by_default=True):
+        with index.open_index() as ix:
+            return ix.parse_query_lenient(
+                query_str,
+                self.default_fields,
+                conjunction_by_default=conjunction_by_default,
+            )
+
+    def _parse_ok(self, query_str, **kwargs):
+        """Parse and assert no errors. Returns query string repr."""
+        query, errors = self._parse(query_str, **kwargs)
+        self.assertEqual(
+            errors,
+            [],
+            f"Unexpected parse errors for '{query_str}': {errors}",
+        )
+        return str(query)
+
+    def _parse_lenient(self, query_str, **kwargs):
+        """Parse and return query string repr, ignoring errors."""
+        query, _errors = self._parse(query_str, **kwargs)
+        return str(query)
+
+    # --- Structural checks (not covered by integration tests) ---
+
+    def test_conjunction_by_default(self):
+        and_result = self._parse_ok("bank AND statement")
+        default_result = self._parse_ok("bank statement")
+        self.assertEqual(and_result, default_result)
+
+    def test_or_produces_different_query_than_and(self):
+        and_result = self._parse_ok("bank AND statement")
+        or_result = self._parse_ok("bank OR statement")
+        self.assertNotEqual(and_result, or_result)
+
+    def test_phrase_different_from_and(self):
+        phrase = self._parse_ok('"bank statement"')
+        and_query = self._parse_ok("bank AND statement")
+        self.assertNotEqual(phrase, and_query)
+
+    def test_field_query_produces_term_query(self):
+        """A field-specific query should target a single field, not expand to all defaults."""
+        result = self._parse_ok("title:invoice")
+        self.assertIn("termquery", result.lower())
+
+    def test_field_query_different_from_free_text(self):
+        """title:invoice should differ from just 'invoice' (which expands to all fields)."""
+        field_result = self._parse_ok("title:invoice")
+        free_result = self._parse_ok("invoice")
+        self.assertNotEqual(field_result, free_result)
+
+    # --- Range and boost parsing (no indexed docs in integration tests) ---
+
+    def test_inclusive_range(self):
+        result = self._parse_lenient("title:[a TO z]")
+        self.assertIn("rangequery", result.lower())
+
+    def test_date_range(self):
+        result = self._parse_lenient(
+            "added:[2025-01-01T00:00:00+00:00 TO 2025-12-31T23:59:59+00:00]",
+        )
+        self.assertIn("2025-01-01", result)
+        self.assertIn("2025-12-31", result)
+        self.assertIn("date", result.lower())
+
+    def test_boost_term(self):
+        result = self._parse_ok("bank^2.0")
+        self.assertIn("bank", result.lower())
+        self.assertIn("2", result)
+
+    def test_boost_phrase(self):
+        result = self._parse_ok('"bank statement"^3.0')
+        self.assertIn("bank", result.lower())
+
+    # --- Edge cases (malformed input) ---
+
+    def test_empty_query(self):
+        result = self._parse_lenient("")
+        self.assertIsNotNone(result)
+
+    def test_special_chars_only(self):
+        result = self._parse_lenient("!!!")
+        self.assertIsNotNone(result)
+
+    def test_unbalanced_quotes_lenient(self):
+        result = self._parse_lenient('"bank statement')
+        self.assertIn("bank", result.lower())
+
+    def test_unknown_field_lenient(self):
+        result = self._parse_lenient("nonexistent_field:test")
+        self.assertIsNotNone(result)
+
+
+class TestPreprocessQuery(SimpleTestCase):
+    """
+    Unit tests for preprocess_query: the single entry point that chains
+    all rewrite steps before Tantivy parsing.
+    """
+
+    def test_plain_words_unchanged(self):
+        query = preprocess_query("bank statement")
+        self.assertIn("bank", query)
+        self.assertIn("statement", query)
+
+    def test_comma_joins_with_and(self):
+        query = preprocess_query("invoice, tag:important")
+        self.assertIn("AND", query)
+        self.assertIn("invoice", query)
+        self.assertIn("tag:important", query)
+
+    def test_explicit_or_preserved(self):
+        query = preprocess_query("bank OR statement")
+        self.assertIn("OR", query)
+
+    def test_explicit_not_preserved(self):
+        query = preprocess_query("bank NOT statement")
+        self.assertIn("NOT", query)
+
+    def test_phrases_preserved(self):
+        query = preprocess_query('"bank statement"')
+        self.assertIn('"bank statement"', query)
+
+    def test_mixed_comma_and_boolean(self):
+        query = preprocess_query("bank OR credit, tag:finance")
+        self.assertIn("bank", query)
+        self.assertIn("credit", query)
+        self.assertIn("tag:finance", query)
+        self.assertIn("AND", query)
+
+
+@override_settings(TIME_ZONE="UTC")
+class TestPreprocessQueryDates(SimpleTestCase):
+    """
+    Tests that preprocess_query correctly rewrites date expressions
+    (both natural keywords and Whoosh-style expressions) into Tantivy ISO ranges.
+    """
+
+    def _preprocess_with_now(self, query: str, now_dt: datetime) -> str:
+        with mock.patch("documents.index.now", return_value=now_dt):
+            return preprocess_query(query)
+
+    def test_today_keyword(self):
+        result = self._preprocess_with_now(
+            "added:today",
+            datetime(2025, 7, 20, 15, 0, 0, tzinfo=timezone.utc),
+        )
+        self.assertIn("added:[2025-07-20T00:00:00+00:00 TO 2025-07-20T23:59:59", result)
+
+    def test_yesterday_keyword(self):
+        result = self._preprocess_with_now(
+            "added:yesterday",
+            datetime(2025, 7, 20, 15, 0, 0, tzinfo=timezone.utc),
+        )
+        self.assertIn("added:[2025-07-19T00:00:00+00:00 TO 2025-07-19T23:59:59", result)
+
+    def test_date_keyword_with_free_text(self):
+        result = self._preprocess_with_now(
+            "invoice, added:today",
+            datetime(2025, 7, 20, 15, 0, 0, tzinfo=timezone.utc),
+        )
+        self.assertIn("invoice", result)
+        self.assertIn("added:[2025-07-20", result)
+        self.assertIn("AND", result)
+
+
+class TestTantivySearchIntegration(DirectoriesMixin, TestCase):
+    """
+    Integration tests that index real documents and verify that Tantivy
+    query syntax produces correct search results.
+
+    Covers: AND, OR, NOT, phrases, phrase slop (~N), field queries,
+    boosting, parentheses grouping.
+    """
+
+    default_fields = [
+        "content",
+        "title",
+        "correspondent",
+        "tag",
+        "type",
+        "notes",
+        "custom_fields",
+    ]
+
+    def setUp(self):
+        super().setUp()
+        self.d1 = Document.objects.create(
+            title="invoice from bank",
+            content="the quick brown fox jumps over the lazy dog",
+            checksum="int1",
+        )
+        self.d2 = Document.objects.create(
+            title="bank statement august",
+            content="monthly statement for credit card payment",
+            checksum="int2",
+        )
+        self.d3 = Document.objects.create(
+            title="tax return",
+            content="annual tax return filed with government agency",
+            checksum="int3",
+        )
+        self.d4 = Document.objects.create(
+            title="receipt from shop",
+            content="bought groceries and paid with credit card at the shop",
+            checksum="int4",
+        )
+        for doc in [self.d1, self.d2, self.d3, self.d4]:
+            index.add_or_update_document(doc)
+
+    def _search(self, query_str, *, conjunction_by_default=True):
+        """Search the index and return matching document PKs."""
+        q_str = preprocess_query(query_str)
+        with index.open_index() as ix:
+            query, _errors = ix.parse_query_lenient(
+                q_str,
+                self.default_fields,
+                conjunction_by_default=conjunction_by_default,
+            )
+            searcher = ix.searcher()
+            results = searcher.search(query, limit=100)
+            return {
+                searcher.doc(doc_addr)["id"][0] for _score, doc_addr in results.hits
+            }
+
+    # --- Single term ---
+
+    def test_single_term(self):
+        ids = self._search("bank")
+        self.assertIn(self.d1.pk, ids)
+        self.assertIn(self.d2.pk, ids)
+        self.assertNotIn(self.d3.pk, ids)
+
+    # --- AND (implicit via conjunction_by_default) ---
+
+    def test_implicit_and(self):
+        """'bank statement' with conjunction_by_default → both terms required."""
+        ids = self._search("bank statement")
+        self.assertIn(self.d2.pk, ids)  # has both in title
+        # d1 has 'bank' in title but not 'statement' in content or title
+        self.assertNotIn(self.d3.pk, ids)
+
+    def test_explicit_and(self):
+        ids = self._search("credit AND card")
+        self.assertIn(self.d2.pk, ids)
+        self.assertIn(self.d4.pk, ids)
+        self.assertNotIn(self.d1.pk, ids)
+
+    # --- OR ---
+
+    def test_explicit_or(self):
+        ids = self._search("tax OR bank")
+        self.assertIn(self.d1.pk, ids)  # bank
+        self.assertIn(self.d2.pk, ids)  # bank
+        self.assertIn(self.d3.pk, ids)  # tax
+        self.assertNotIn(self.d4.pk, ids)
+
+    # --- NOT / exclusion ---
+
+    def test_minus_exclusion(self):
+        ids = self._search("credit -shop")
+        self.assertIn(self.d2.pk, ids)  # credit, no shop
+        self.assertNotIn(self.d4.pk, ids)  # credit + shop
+
+    # --- Phrases ---
+
+    def test_phrase_match(self):
+        """Exact phrase 'brown fox' should match d1 only."""
+        ids = self._search('"brown fox"')
+        self.assertIn(self.d1.pk, ids)
+        self.assertEqual(len(ids), 1)
+
+    def test_phrase_no_match(self):
+        """'fox brown' (reversed) should not match as a phrase."""
+        ids = self._search('"fox brown"')
+        self.assertNotIn(self.d1.pk, ids)
+
+    # --- Phrase slop (word distance) ---
+
+    def test_phrase_slop(self):
+        """'quick fox'~2 should match d1 ('quick brown fox' — distance 1)."""
+        ids = self._search('"quick fox"~2')
+        self.assertIn(self.d1.pk, ids)
+
+    def test_phrase_slop_too_small(self):
+        """'quick lazy'~1 should NOT match d1 (distance is 4)."""
+        ids = self._search('"quick lazy"~1')
+        self.assertNotIn(self.d1.pk, ids)
+
+    # --- Field-specific queries ---
+
+    def test_field_title(self):
+        ids = self._search("title:invoice")
+        self.assertIn(self.d1.pk, ids)
+        self.assertNotIn(self.d2.pk, ids)
+
+    def test_field_content(self):
+        ids = self._search("content:groceries")
+        self.assertIn(self.d4.pk, ids)
+        self.assertEqual(len(ids), 1)
+
+    # --- Grouping with parentheses ---
+
+    def test_parentheses_grouping(self):
+        """(tax OR bank) -statement → tax return + invoice from bank."""
+        ids = self._search("(tax OR bank) -statement")
+        self.assertIn(self.d1.pk, ids)  # bank, no statement
+        self.assertIn(self.d3.pk, ids)  # tax, no statement
+        self.assertNotIn(self.d2.pk, ids)  # bank + statement
+
+    # --- Boosting ---
+
+    def test_boost_affects_ranking(self):
+        """'bank^10 OR tax' — bank docs should rank higher than tax docs."""
+        with index.open_index() as ix:
+            # Use parse_query_lenient directly to avoid preprocess_query wrapping
+            query, _ = ix.parse_query_lenient(
+                "bank^10 OR tax",
+                self.default_fields,
+                conjunction_by_default=False,
+            )
+            searcher = ix.searcher()
+            results = searcher.search(query, limit=100)
+            ranked_ids = [searcher.doc(addr)["id"][0] for _score, addr in results.hits]
+        # bank docs (d1, d2) should appear before tax doc (d3)
+        bank_positions = [ranked_ids.index(pk) for pk in [self.d1.pk, self.d2.pk]]
+        tax_position = ranked_ids.index(self.d3.pk)
+        self.assertTrue(all(bp < tax_position for bp in bank_positions))
+
+    # --- Plus (required) ---
+
+    def test_plus_required(self):
+        ids = self._search("+credit +shop")
+        self.assertIn(self.d4.pk, ids)
+        self.assertNotIn(self.d2.pk, ids)  # credit but no shop
+
+    # --- Complex combinations ---
+
+    def test_complex_query(self):
+        """title:bank AND (credit OR groceries) → d2 (bank+credit), not d4 (no bank in title)."""
+        ids = self._search("title:bank AND (credit OR groceries)")
+        self.assertIn(self.d2.pk, ids)
+        self.assertNotIn(self.d4.pk, ids)  # no 'bank' in title

--- a/src/documents/views.py
+++ b/src/documents/views.py
@@ -3055,10 +3055,9 @@ class SystemStatusView(PassUserMixin):
 
         index_error = None
         try:
-            ix = index.open_index()
             index_status = "OK"
             index_last_modified = make_aware(
-                datetime.fromtimestamp(ix.last_modified()),
+                datetime.fromtimestamp(index.get_index_last_modified()),
             )
         except Exception as e:
             index_status = "ERROR"

--- a/src/documents/views.py
+++ b/src/documents/views.py
@@ -1382,6 +1382,7 @@ class UnifiedSearchViewSet(DocumentViewSet):
                 self.request.query_params,
                 self.paginator.get_page_size(self.request),
                 filter_queryset=filtered_queryset,
+                user=self.request.user,
             )
         else:
             return filtered_queryset
@@ -1394,22 +1395,27 @@ class UnifiedSearchViewSet(DocumentViewSet):
                 with index.open_index_searcher() as s:
                     self.searcher = s
                     queryset = self.filter_queryset(self.get_queryset())
+                    # TODO: This fails
+                    # print(1)
+                    # print(queryset)
                     page = self.paginate_queryset(queryset)
-
+                    # print(2)
                     serializer = self.get_serializer(page, many=True)
+                    # print(3)
                     response = self.get_paginated_response(serializer.data)
-
+                    # print(4)
                     response.data["corrected_query"] = (
                         queryset.suggested_correction
                         if hasattr(queryset, "suggested_correction")
                         else None
                     )
-
+                    # print(5)
                     return response
             except NotFound:
                 raise
             except Exception as e:
                 logger.warning(f"An error occurred listing search results: {e!s}")
+                raise e
                 return HttpResponseBadRequest(
                     "Error listing search results, check logs for more detail.",
                 )

--- a/src/paperless/settings.py
+++ b/src/paperless/settings.py
@@ -283,7 +283,7 @@ EMPTY_TRASH_DIR = (
 # Lock file for synchronizing changes to the MEDIA directory across multiple
 # threads.
 MEDIA_LOCK = MEDIA_ROOT / "media.lock"
-INDEX_DIR = DATA_DIR / "index"
+INDEX_DIR = __get_path("PAPERLESS_INDEX_DIR", DATA_DIR / "index")
 MODEL_FILE = __get_path(
     "PAPERLESS_MODEL_FILE",
     DATA_DIR / "classification_model.pickle",
@@ -762,6 +762,9 @@ if os.getenv("PAPERLESS_DBENGINE") == "mariadb":
     SILENCED_SYSTEM_CHECKS = ["mysql.W003"]
 
 DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
+
+# Set to 0 to disable fuzzy search
+ADVANCED_FUZZY_SEARCH_TRESHOLD = __get_int("PAPERLESS_ADVANCED_FUZZY_SEARCH_TRESHOLD", 0)
 
 ###############################################################################
 # Internationalization                                                        #

--- a/src/paperless/settings.py
+++ b/src/paperless/settings.py
@@ -764,8 +764,10 @@ if os.getenv("PAPERLESS_DBENGINE") == "mariadb":
 DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
 
 # Set to 0 to disable fuzzy search
-ADVANCED_FUZZY_SEARCH_TRESHOLD = __get_int("PAPERLESS_ADVANCED_FUZZY_SEARCH_TRESHOLD", 0)
-
+ADVANCED_FUZZY_SEARCH_TRESHOLD = __get_int(
+    "PAPERLESS_ADVANCED_FUZZY_SEARCH_TRESHOLD",
+    0,
+)
 ###############################################################################
 # Internationalization                                                        #
 ###############################################################################

--- a/src/paperless/views.py
+++ b/src/paperless/views.py
@@ -68,17 +68,11 @@ class StandardPagination(PageNumberPagination):
         )
 
     def get_all_result_ids(self):
-        # print("get_all_result_ids")
         query = self.page.paginator.object_list
-        ids = []
         if isinstance(query, DelayedQuery):
-            try:
-                ids.extend(query.saved_results.get(0).doc_ids)
-            except Exception as e:
-                print(f"Exception: {e}")
+            return query._get_all_ids()
         else:
-            ids = list(query.values_list("pk", flat=True))
-        return ids
+            return list(query.values_list("pk", flat=True))
 
     def get_paginated_response_schema(self, schema):
         response_schema = super().get_paginated_response_schema(schema)

--- a/src/paperless/views.py
+++ b/src/paperless/views.py
@@ -68,19 +68,16 @@ class StandardPagination(PageNumberPagination):
         )
 
     def get_all_result_ids(self):
+        # print("get_all_result_ids")
         query = self.page.paginator.object_list
+        ids = []
         if isinstance(query, DelayedQuery):
             try:
-                ids = [
-                    query.searcher.ixreader.stored_fields(
-                        doc_num,
-                    )["id"]
-                    for doc_num in query.saved_results.get(0).results.docs()
-                ]
-            except Exception:
-                pass
+                ids.extend(query.saved_results.get(0).doc_ids)
+            except Exception as e:
+                print(f"Exception: {e}")
         else:
-            ids = self.page.paginator.object_list.values_list("pk", flat=True)
+            ids = list(query.values_list("pk", flat=True))
         return ids
 
     def get_paginated_response_schema(self, schema):

--- a/uv.lock
+++ b/uv.lock
@@ -2042,6 +2042,7 @@ dependencies = [
     { name = "regex", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "scikit-learn", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "setproctitle", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "tantivy", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "tika-client", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "tqdm", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "watchdog", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
@@ -2184,6 +2185,7 @@ requires-dist = [
     { name = "regex", specifier = ">=2025.9.18" },
     { name = "scikit-learn", specifier = "~=1.7.0" },
     { name = "setproctitle", specifier = "~=1.3.4" },
+    { name = "tantivy", specifier = "==0.25.1" },
     { name = "tika-client", specifier = "~=0.10.0" },
     { name = "tqdm", specifier = "~=4.67.1" },
     { name = "watchdog", specifier = "~=6.0" },
@@ -3660,6 +3662,38 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e5/40/edede8dd6977b0d3da179a342c198ed100dd2aba4be081861ee5911e4da4/sqlparse-0.5.3.tar.gz", hash = "sha256:09f67787f56a0b16ecdbde1bfc7f5d9c3371ca683cfeaa8e6ff60b4807ec9272", size = 84999, upload-time = "2024-12-10T12:05:30.728Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a9/5c/bfd6bd0bf979426d405cc6e71eceb8701b148b16c21d2dc3c261efc61c7b/sqlparse-0.5.3-py3-none-any.whl", hash = "sha256:cf2196ed3418f3ba5de6af7e82c694a9fbdbfecccdfc72e281548517081f16ca", size = 44415, upload-time = "2024-12-10T12:05:27.824Z" },
+]
+
+[[package]]
+name = "tantivy"
+version = "0.25.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/f9/0cd3955d155d3e3ef74b864769514dd191e5dacba9f0beb7af2d914942ce/tantivy-0.25.1.tar.gz", hash = "sha256:68a3314699a7d18fcf338b52bae8ce46a97dde1128a3e47e33fa4db7f71f265e", size = 75120, upload_time = "2025-12-02T11:57:12.997Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/80/f7/2276bed3bed983ce2970dc70e3571f372587fe4f5f2bac1d6d617df08fa3/tantivy-0.25.1-cp310-cp310-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:7aa587a3dc9470584cacf5e3640fee93d12ec5f10109669c1f47c4e90820b958", size = 7638510, upload_time = "2025-12-02T11:56:08.754Z" },
+    { url = "https://files.pythonhosted.org/packages/20/8c/078dc50570e243414356b05633f52fe544b85179281ffa9f1fe05d76bbd8/tantivy-0.25.1-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:56d77fe667595693d9fa5f0b4545776d84da9526bab0273b3fc6c7536dc0d8a2", size = 3932659, upload_time = "2025-12-02T11:56:10.621Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/dc/281c48436a1e3178b58fe463af314434fe0f3a4ec0c7588a362900e0c69e/tantivy-0.25.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5ba8c347cd48595fcaeabb28a909ebce92cf9c5e5c84ab5ba1136a280a307b5c", size = 4197430, upload_time = "2025-12-02T11:56:12.65Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/6c/61e6e0b0a350007d10a9b66a35703361d3345e14e7a7cc83494776b2a054/tantivy-0.25.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:aa7c4932e8fde1f09f2d46226060e827e197c2749abdc6129d73a752773adc38", size = 4184055, upload_time = "2025-12-02T11:56:14.647Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/7a/8a277f377e8a151fc0e71d4ffc1114aefb6e5e1c7dd609fed0955cf34ed8/tantivy-0.25.1-cp311-cp311-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:d363d7b4207d3a5aa7f0d212420df35bed18bdb6bae26a2a8bd57428388b7c29", size = 7637033, upload_time = "2025-12-02T11:56:18.104Z" },
+    { url = "https://files.pythonhosted.org/packages/71/31/8b4acdedfc9f9a2d04b1340d07eef5213d6f151d1e18da0cb423e5f090d2/tantivy-0.25.1-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:8f4389cf1d889a1df7c5a3195806b4b56c37cee10d8a26faaa0dea35a867b5ff", size = 3932180, upload_time = "2025-12-02T11:56:19.833Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/dc/3e8499c21b4b9795e8f2fc54c68ce5b92905aaeadadaa56ecfa9180b11b1/tantivy-0.25.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:99864c09fc54652c3c2486cdf13f86cdc8200f4b481569cb291e095ca5d496e5", size = 4197620, upload_time = "2025-12-02T11:56:21.496Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/8e/f2ce62fffc811eb62bead92c7b23c2e218f817cbd54c4f3b802e03ba1438/tantivy-0.25.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:05abf37ddbc5063c575548be0d62931629c086bff7a5a1b67cf5a8f5ebf4cd8c", size = 4183794, upload_time = "2025-12-02T11:56:23.215Z" },
+    { url = "https://files.pythonhosted.org/packages/41/e7/6849c713ed0996c7628324c60512c4882006f0a62145e56c624a93407f90/tantivy-0.25.1-cp312-cp312-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:90fd919e5f611809f746560ecf36eb9be824dec62e21ae17a27243759edb9aa1", size = 7621494, upload_time = "2025-12-02T11:56:27.069Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/22/c3d8294600dc6e7fa350daef9ff337d3c06e132b81df727de9f7a50c692a/tantivy-0.25.1-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:4613c7cf6c23f3a97989819690a0f956d799354957de7a204abcc60083cebe02", size = 3925219, upload_time = "2025-12-02T11:56:29.403Z" },
+    { url = "https://files.pythonhosted.org/packages/41/fc/cbb1df71dd44c9110eff4eaaeda9d44f2d06182fe0452193be20ddfba93f/tantivy-0.25.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c477bd20b4df804d57dfc5033431bef27cde605695ae141b03abbf6ebc069129", size = 4198699, upload_time = "2025-12-02T11:56:31.359Z" },
+    { url = "https://files.pythonhosted.org/packages/47/4d/71abb78b774073c3ce12a4faa4351a9d910a71ffa3659526affba163873d/tantivy-0.25.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f9b1a1ba1113c523c7ff7b10f282d6c4074006f7ef8d71e1d973d51bf7291ddb", size = 4183585, upload_time = "2025-12-02T11:56:33.317Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/25/73cfbcf1a8ea49be6c42817431cac46b70a119fe64da903fcc2d92b5b511/tantivy-0.25.1-cp313-cp313-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:f51ff7196c6f31719202080ed8372d5e3d51e92c749c032fb8234f012e99744c", size = 7622530, upload_time = "2025-12-02T11:56:36.839Z" },
+    { url = "https://files.pythonhosted.org/packages/12/c8/c0d7591cdf4f7e7a9fc4da786d1ca8cd1aacffaa2be16ea6d401a8e4a566/tantivy-0.25.1-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:550e63321bfcacc003859f2fa29c1e8e56450807b3c9a501c1add27cfb9236d9", size = 3925637, upload_time = "2025-12-02T11:56:38.425Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/09/bedfc223bffec7641b417dd7ab071134b2ef8f8550e9b1fb6014657ef52e/tantivy-0.25.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fde31cc8d6e122faf7902aeea32bc008a429a6e8904e34d3468126a3ec01b016", size = 4197322, upload_time = "2025-12-02T11:56:40.411Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/f1/1fa5183500c8042200c9f2b840d34f5bbcfb434a1ee750e7132262d2a5c9/tantivy-0.25.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b11bd5a518b0be645320b47af8493f6a40c4f3234313e37adcf4534a564d27dd", size = 4183143, upload_time = "2025-12-02T11:56:42.048Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/2f/581519492226f97d23bd0adc95dad991ebeaa73ea6abc8bff389a3096d9a/tantivy-0.25.1-cp313-cp313t-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:dae99e75b7eaa9bf5bd16ab106b416370f08c135aed0e117d62a3201cd1ffe36", size = 7610316, upload_time = "2025-12-02T11:56:45.927Z" },
+    { url = "https://files.pythonhosted.org/packages/91/40/5d7bc315ab9e6a22c5572656e8ada1c836cfa96dccf533377504fbc3c9d9/tantivy-0.25.1-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:506e9533c5ef4d3df43bad64ffecc0aa97c76e361ea610815dc3a20a9d6b30b3", size = 3919882, upload_time = "2025-12-02T11:56:48.469Z" },
+    { url = "https://files.pythonhosted.org/packages/02/b9/e0ef2f57a6a72444cb66c2ffbc310ab33ffaace275f1c4b0319d84ea3f18/tantivy-0.25.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5dbd4f8f264dacbcc9dee542832da2173fd53deaaea03f082d95214f8b5ed6bc", size = 4196031, upload_time = "2025-12-02T11:56:50.151Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/02/bf3f8cacfd08642e14a73f7956a3fb95d58119132c98c121b9065a1f8615/tantivy-0.25.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:824c643ccb640dd9e35e00c5d5054ddf3323f56fe4219d57d428a9eeea13d22c", size = 4183437, upload_time = "2025-12-02T11:56:51.818Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/44/9f1d67aa5030f7eebc966c863d1316a510a971dd8bb45651df4acdfae9ed/tantivy-0.25.1-cp314-cp314-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:7f5d29ae85dd0f23df8d15b3e7b341d4f9eb5a446bbb9640df48ac1f6d9e0c6c", size = 7623723, upload_time = "2025-12-02T11:56:55.066Z" },
+    { url = "https://files.pythonhosted.org/packages/db/30/6e085bd3ed9d12da3c91c185854abd70f9dfd35fb36a75ea98428d42c30b/tantivy-0.25.1-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:f2d2938fb69a74fc1bb36edfaf7f0d1596fa1264db0f377bda2195c58bcb6245", size = 3926243, upload_time = "2025-12-02T11:56:57.058Z" },
+    { url = "https://files.pythonhosted.org/packages/32/f5/a00d65433430f51718e5cc6938df571765d7c4e03aedec5aef4ab567aa9b/tantivy-0.25.1-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4f5ff124c4802558e627091e780b362ca944169736caba5a372eef39a79d0ae0", size = 4207186, upload_time = "2025-12-02T11:56:58.803Z" },
+    { url = "https://files.pythonhosted.org/packages/19/63/61bdb12fc95f2a7f77bd419a5149bfa9f28caa76cb569bf2b6b06e1d033e/tantivy-0.25.1-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:43b80ef62a340416139c93d19264e5f808da48e04f9305f1092b8ed22be0a5be", size = 4187312, upload_time = "2025-12-02T11:57:00.595Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!--
Note: All PRs with code changes should be targeted to the `dev` branch, pure documentation changes can target `main`
-->
2026-04-03: the tantivy backend has been implemented and merged in https://github.com/paperless-ngx/paperless-ngx/pull/12471

2026-02-27: the commits have been squashed and rebased on the v2.20.x release. For old commits and full history, check this backup branch: https://github.com/Merinorus/paperless-ngx/tree/backup-feature-tantivy

## Proposed change

POC: Replacing whoosh by tantivy for advanced search. See discussion https://github.com/paperless-ngx/paperless-ngx/discussions/11352#discussioncomment-15064270.

Differences compared to Whoosh:
- Search syntax is similar to Lucene: https://docs.rs/tantivy/latest/tantivy/query/struct.QueryParser.html
- Optional setting: fuzzy search (with exact terms scoring higher in the results)
- The scoring algorithm is similar (BM25F?) but result scores are differents.
- Search is now diacritic insensitive, autocomplete as well.
- The `NOT` keyword is not well supported, use `-` instead: https://github.com/quickwit-oss/tantivy/issues/1980


## TODO

- [ ] index optimize task to remove?
- [x] check note serialization (unused variable?)
- [x] autocomplete: sort terms by frequency, not alphabetically
- [ ] if a long term triggers fuzzy search, should fuzzy search be for all terms (even the short ones)?
- [ ] fuzzy search in special fields eg `title:(my fuzzy content)`
- [ ] Parse correctly multiple words in a given field, eg: `my content tag:(multiple word tag)`
- [ ] API query param: limit
- [x] Order by custom field and manual sorting: see https://github.com/paperless-ngx/paperless-ngx/pull/11383
- [x] New date patterns: see https://github.com/paperless-ngx/paperless-ngx/issues/11411
- [x] Sometimes less than 50 docs per page in the results?
- [ ] ~~Cache already searched pages~~
- [x] Better diacritic handling ("les" should return "les" or "lès")
- [x] Search
- [x] Sorted_by
- [x] Reverse
- [x] Highlight with user permission
- [x] More like this
- [x] More like this : sorted by, reverse
- [x] Page result: mask?
- [x] Score ? See what the front-end bar means with Whoosh
- [x] Pagination
- [x] Filter : get the infos (nb docs by correspondent, by tag etc.)
- [x] Note highlight
- [x] Wildcards, prefixes, fuzzy search?
- [x] Index storage
- [x] Note: when a note is deleted, delete it from the index 
- [x] Local date parser support ("1 year from now" etc) -W still using Whoosh
- [ ] Migrate or rebuild the index when migrating from Whoosh to Tantivy
- [x] Writer -> Async Writer ?
- [x] text -> string for fields that should not be tokenized
- [x] Arabic support for partial words
- [x] CJK support for partial words -> bigram
- [ ] Concurrency, operation order, thread safety, lock etc. (celery queue ?)
- [x] Optimize autocomplete word indexing ? If the concurrency was properly managed, we could do one word = one document -> autocomplete words are now as a list per paperless-ngx document
- [x] See option "index_option"
- [x] See option "tokenizer_name"
- [x] See option "fast" (Lucene DocValues equivalent)
- [ ] Merge policy / Merge on scheduled task?
- [ ] Memory threshold before writing
- [ ] Handle commit errors
- [ ] Read & Write threads
- [x] Suggestion corrections?
- [ ] Handle "too many results", e.g. > 1000


## TODO - Tests

- [x] Updating a tantivy doc does a delete by id first
- [ ] Diacritics insensitivity
## TODO (Bonus)

This is not present in the current Paperless-ngx implementation (Whoosh) but could be implemented:
- [x] Autocomplete from words in notes
- [x] Autocomplete from words in title ?
